### PR TITLE
Use `items` instead of `iteritems` for Python 3 compatibility

### DIFF
--- a/lib/cretonne/meta/cretonne/__init__.py
+++ b/lib/cretonne/meta/cretonne/__init__.py
@@ -184,7 +184,7 @@ class SettingGroup(object):
                 .format(self, SettingGroup._current))
         SettingGroup._current = None
         if globs:
-            for name, obj in globs.iteritems():
+            for name, obj in globs.items():
                 if isinstance(obj, Setting):
                     assert obj.name is None, obj.name
                     obj.name = name
@@ -761,7 +761,7 @@ class InstructionFormat(object):
         all the InstructionFormat objects and set their name from the dict key.
         This is used to name a bunch of global variables in a module.
         """
-        for name, obj in globs.iteritems():
+        for name, obj in globs.items():
             if isinstance(obj, InstructionFormat):
                 assert obj.name is None
                 obj.name = name


### PR DESCRIPTION
Ran into this while building with my (somewhat unusual) configuration of having `python` refer to `python3` on my machine. `iteritems` was renamed to `items` in Python 3 (and `items` already exists in Python 2) so this code works on both versions (if being slightly more inefficient on Python 2).