### PR TITLE
conditional compilation of ISA targets

### DIFF
--- a/lib/reader/src/error.rs
+++ b/lib/reader/src/error.rs
@@ -19,6 +19,8 @@ pub struct Error {
     pub location: Location,
     /// Error message.
     pub message: String,
+    /// Error because of unsupported ISA
+    pub unsupported: bool,
 }
 
 impl fmt::Display for Error {
@@ -36,6 +38,7 @@ macro_rules! err {
         Err($crate::Error {
             location: $loc.clone(),
             message: String::from($msg),
+            unsupported: false,
         })
     };
 
@@ -43,6 +46,25 @@ macro_rules! err {
         Err($crate::Error {
             location: $loc.clone(),
             message: format!( $fmt, $( $arg ),+ ),
+            unsupported: false,
+        })
+    };
+}
+
+macro_rules! unsupported_err {
+    ( $loc:expr, $msg:expr ) => {
+        Err($crate::Error {
+            location: $loc.clone(),
+            message: String::from($msg),
+            unsupported: true,
+        })
+    };
+
+    ( $loc:expr, $fmt:expr, $( $arg:expr ),+ ) => {
+        Err($crate::Error {
+            location: $loc.clone(),
+            message: format!( $fmt, $( $arg ),+ ),
+            unsupported: true,
         })
     };
 }

--- a/src/filetest/mod.rs
+++ b/src/filetest/mod.rs
@@ -20,7 +20,17 @@ mod verifier;
 mod legalizer;
 
 /// The result of running the test in a file.
-pub type TestResult = Result<time::Duration, String>;
+pub type TestResult = Result<Success, String>;
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+/// Test success value
+pub enum Success {
+    /// Duration of test execution.
+    Duration(time::Duration),
+
+    /// Test unsupported.
+    Unsupported(String),
+}
 
 /// Main entry point for `cton-util test`.
 ///


### PR DESCRIPTION
Cretonne does not need to compile all available ISAs. This is useful for
e.g. JIT compilers, which only need to support the native ISA.

Targets can be specified with the environment variable `CRETONNE_TARGETS`.
There are three supported values:

1. `all` - compile all ISAs
2. `native` - compile only current ISA
3.  non-empty comma-separated list of ISAs

implements #13