### PR TITLE
remove old `is_terminating` function

### DIFF
--- a/lib/cretonne/meta/gen_instr.py
+++ b/lib/cretonne/meta/gen_instr.py
@@ -272,17 +272,22 @@ def gen_opcodes(groups, fmt):
     fmt.line()
 
     with fmt.indented('impl Opcode {', '}'):
-        attrs = ['is_branch', 'is_terminator', 'can_trap']
+        attrs = [
+            { 'name': 'is_branch', 'comment': 'True for all branch instructions.' },
+            { 'name': 'is_terminator', 'comment': 'True for instructions that terminate EBB.' },
+            { 'name': 'can_trap', 'comment': 'True if instruction could trap.' }
+        ]
 
         for attr in attrs:
             if attr != attrs[0]:
                 fmt.line()
 
-            with fmt.indented('fn {}(self) -> bool {{'
-                              .format(attr), '}'):
+            fmt.doc_comment(attr['comment'])
+            with fmt.indented('pub fn {}(self) -> bool {{'
+                              .format(attr['name']), '}'):
                 with fmt.indented('match self {', '}'):
                     for i in instrs:
-                        if getattr(i, attr):
+                        if getattr(i, attr['name']):
                             fmt.format('Opcode::{} => true,', i.camel_name, i.name)
 
                     fmt.line('_ => false')

--- a/lib/cretonne/src/ir/instructions.rs
+++ b/lib/cretonne/src/ir/instructions.rs
@@ -465,16 +465,6 @@ impl InstructionData {
             _ => CallInfo::NotACall,
         }
     }
-
-    /// Return true if an instruction is terminating, or false otherwise.
-    pub fn is_terminating<'a>(&'a self) -> bool {
-        match self {
-            &InstructionData::Jump { .. } => true,
-            &InstructionData::Return { .. } => true,
-            &InstructionData::Nullary { .. } => true,
-            _ => false,
-        }
-    }
 }
 
 /// Information about branch and jump instructions.

--- a/lib/cretonne/src/verifier.rs
+++ b/lib/cretonne/src/verifier.rs
@@ -109,7 +109,7 @@ impl<'a> Verifier<'a> {
 
     fn ebb_integrity(&self, ebb: Ebb, inst: Inst) -> Result<()> {
 
-        let is_terminator = self.func.dfg[inst].is_terminating();
+        let is_terminator = self.func.dfg[inst].opcode().is_terminator();
         let is_last_inst = self.func.layout.last_inst(ebb) == inst;
 
         if is_terminator && !is_last_inst {


### PR DESCRIPTION
for InstructionData. Use generated `is_terminator()` for `Opcode`
instead. `is_terminator`, `can_trap` and `is_branch` functions are now
public.

fix syntax error