### PR TITLE
Fix some typos in the documentation

### DIFF
--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -882,7 +882,7 @@ Glossary
         - Type and flags of each argument.
         - Type and flags of each return value.
 
-        Not all function atributes are part of the signature. For example, a
+        Not all function attributes are part of the signature. For example, a
         function that never returns could be marked as ``noreturn``, but that
         is not necessary to know when calling it, so it is just an attribute,
         and not part of the signature.

--- a/docs/regalloc.rst
+++ b/docs/regalloc.rst
@@ -206,7 +206,7 @@ top-down order, and each value define by the instruction is assigned an
 available register. With this iteration order, every value that is live at an
 instruction has already been assigned to a register.
 
-This coloring algorith works if the following condition holds:
+This coloring algorithm works if the following condition holds:
 
     At every instruction, consider the values live through the instruction. No
     matter how the live values have been assigned to registers, there must be

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -139,7 +139,7 @@ run will also have the RISC-V specific flag ``supports_m`` disabled.
 Filecheck
 ---------
 
-Many of the test commands bescribed below use *filecheck* to verify their
+Many of the test commands described below use *filecheck* to verify their
 output. Filecheck is a Rust implementation of the LLVM tool of the same name.
 See the :file:`lib/filecheck` `documentation <https://docs.rs/filecheck/>`_ for
 details of its syntax.


### PR DESCRIPTION
These were found by the spellchecker.