### PR TITLE
Coalesce live range intervals in adjacent EBBs

### DIFF
--- a/lib/cretonne/src/ir/layout.rs
+++ b/lib/cretonne/src/ir/layout.rs
@@ -102,6 +102,13 @@ impl ProgramOrder for Layout {
         let b_seq = self.seq(b);
         a_seq.cmp(&b_seq)
     }
+
+    fn is_ebb_gap(&self, inst: Inst, ebb: Ebb) -> bool {
+        let i = &self.insts[inst];
+        let e = &self.ebbs[ebb];
+
+        i.next.is_none() && i.ebb == e.prev
+    }
 }
 
 // Private methods for dealing with sequence numbers.
@@ -1267,5 +1274,10 @@ mod tests {
         assert_eq!(layout.cmp(e2, e2), Ordering::Equal);
         assert_eq!(layout.cmp(e2, i2), Ordering::Less);
         assert_eq!(layout.cmp(i3, i2), Ordering::Greater);
+
+        assert_eq!(layout.is_ebb_gap(i1, e2), true);
+        assert_eq!(layout.is_ebb_gap(i3, e1), true);
+        assert_eq!(layout.is_ebb_gap(i1, e1), false);
+        assert_eq!(layout.is_ebb_gap(i2, e1), false);
     }
 }

--- a/lib/cretonne/src/ir/progpoint.rs
+++ b/lib/cretonne/src/ir/progpoint.rs
@@ -94,6 +94,11 @@ pub trait ProgramOrder {
     fn cmp<A, B>(&self, a: A, b: B) -> cmp::Ordering
         where A: Into<ExpandedProgramPoint>,
               B: Into<ExpandedProgramPoint>;
+
+    /// Is the range from `inst` to `ebb` just the gap between consecutive EBBs?
+    ///
+    /// This returns true if `inst` is the terminator in the EBB immediately before `ebb`.
+    fn is_ebb_gap(&self, inst: Inst, ebb: Ebb) -> bool;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
LiveRanges represent the live-in range of a value as a sorted
list of intervals. Each interval starts at an EBB and continues
to an instruction. Before this commit, the LiveRange would store
an interval for each EBB. This commit changes the representation
such that intervals continuing from one EBB to another are coalesced
into one.

Fixes #37.