### PR TITLE
Documentation fix for what appears to be a minor copy-paste mistake.

### DIFF
--- a/lib/cretonne/meta/base/instructions.py
+++ b/lib/cretonne/meta/base/instructions.py
@@ -254,8 +254,8 @@ fill = Instruction(
         'fill', r"""
         Load a register value from a stack slot.
 
-        This instruction behaves exactly like :inst:`copy`, but the input
-        value is assigned to a spill slot.
+        This instruction behaves exactly like :inst:`copy`, but creates a new
+        SSA value for the spilled input value.
         """,
         ins=x, outs=a)
 

--- a/lib/cretonne/meta/gen_encoding.py
+++ b/lib/cretonne/meta/gen_encoding.py
@@ -364,12 +364,12 @@ def emit_level2_hashtables(level2_hashtables, offt, level2_doc, fmt):
             if entry:
                 fmt.line(
                         'Level2Entry ' +
-                        '{{ opcode: Opcode::{}, offset: {:#08x} }},'
+                        '{{ opcode: Some(Opcode::{}), offset: {:#08x} }},'
                         .format(entry.inst.camel_name, entry.offset))
             else:
                 fmt.line(
                         'Level2Entry ' +
-                        '{ opcode: Opcode::NotAnOpcode, offset: 0 },')
+                        '{ opcode: None, offset: 0 },')
 
 
 def emit_level1_hashtable(cpumode, level1, offt, fmt):

--- a/lib/cretonne/src/ir/instructions.rs
+++ b/lib/cretonne/src/ir/instructions.rs
@@ -742,7 +742,7 @@ mod tests {
         assert!(x != y);
         y = Opcode::Iadd;
         assert_eq!(x, y);
-        assert_eq!(x.format(), Some(InstructionFormat::Binary));
+        assert_eq!(x.format(), InstructionFormat::Binary);
 
         assert_eq!(format!("{:?}", Opcode::IaddImm), "IaddImm");
         assert_eq!(Opcode::IaddImm.to_string(), "iadd_imm");

--- a/lib/cretonne/src/isa/enc_tables.rs
+++ b/lib/cretonne/src/isa/enc_tables.rs
@@ -53,7 +53,7 @@ impl<OffT: Into<u32> + Copy> Table<Type> for [Level1Entry<OffT>] {
 ///
 /// Empty entries are encoded with a `NotAnOpcode` `opcode` field.
 pub struct Level2Entry<OffT: Into<u32> + Copy> {
-    pub opcode: Opcode,
+    pub opcode: Option<Opcode>,
     pub offset: OffT,
 }
 
@@ -63,12 +63,7 @@ impl<OffT: Into<u32> + Copy> Table<Opcode> for [Level2Entry<OffT>] {
     }
 
     fn key(&self, idx: usize) -> Option<Opcode> {
-        let opc = self[idx].opcode;
-        if opc != Opcode::NotAnOpcode {
-            Some(opc)
-        } else {
-            None
-        }
+        self[idx].opcode
     }
 }
 

--- a/lib/cretonne/src/verifier.rs
+++ b/lib/cretonne/src/verifier.rs
@@ -149,7 +149,7 @@ impl<'a> Verifier<'a> {
         let inst_data = &self.func.dfg[inst];
 
         // The instruction format matches the opcode
-        if inst_data.opcode().format() != Some(InstructionFormat::from(inst_data)) {
+        if inst_data.opcode().format() != InstructionFormat::from(inst_data) {
             return err!(inst, "instruction opcode doesn't match instruction format");
         }
 

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -1088,7 +1088,7 @@ impl<'a> Parser<'a> {
     // Parse the operands following the instruction opcode.
     // This depends on the format of the opcode.
     fn parse_inst_operands(&mut self, ctx: &Context, opcode: Opcode) -> Result<InstructionData> {
-        Ok(match opcode.format().unwrap() {
+        Ok(match opcode.format() {
             InstructionFormat::Nullary => {
                 InstructionData::Nullary {
                     opcode: opcode,


### PR DESCRIPTION
It seems that the documentation for `fill` had been copied from `spill` and not changed appropriately.