### PR TITLE
Added parsing of instruction encodings and result registers specification

### DIFF
--- a/filetests/parser/instruction_encoding.cton
+++ b/filetests/parser/instruction_encoding.cton
@@ -1,0 +1,25 @@
+test cat
+
+isa riscv
+
+; regex: WS=[ \t]*
+
+function foo(i32, i32) {
+ebb1(v0: i32, v1: i32):
+    [-,-] v2 = iadd v0, v1
+    [-] trap
+    [R#1234, %x5, %x11] v6, v7 = iadd_cout v2, v0
+    [Rshamt#beef, %x25] v8 = ishl_imm v6, 2
+    v9 = iadd v8, v7
+    [Iret#5] return v0, v8
+}
+; sameln: function foo(i32, i32) {
+; nextln: $ebb1($v0: i32, $v1: i32):
+; nextln:     [-]$WS $v2 = iadd $v0, $v1
+; nextln:     [-]$WS trap
+; nextln:     [0#1234]$WS $v6, $v7 = iadd_cout $v2, $v0
+; TODO Add the full encoding information available: instruction recipe name and architectural registers if specified
+; nextln:     [2#beef]$WS $v8 = ishl_imm $v6, 2
+; nextln:     [-]$WS $v9 = iadd $v8, $v7
+; nextln:     [3#05]$WS return $v0, $v8
+; nextln: }

--- a/lib/cretonne/meta/cdsl/ast.py
+++ b/lib/cretonne/meta/cdsl/ast.py
@@ -143,22 +143,22 @@ class Var(Expr):
     def is_input(self):
         # type: () -> bool
         """Is this an input value to the src pattern?"""
-        return not self.src_def and not self.dst_def
+        return self.src_def is None and self.dst_def is None
 
     def is_output(self):
-        """Is this an output value, defined in both src and dst patterns?"""
         # type: () -> bool
-        return self.src_def and self.dst_def
+        """Is this an output value, defined in both src and dst patterns?"""
+        return self.src_def is not None and self.dst_def is not None
 
     def is_intermediate(self):
-        """Is this an intermediate value, defined only in the src pattern?"""
         # type: () -> bool
-        return self.src_def and not self.dst_def
+        """Is this an intermediate value, defined only in the src pattern?"""
+        return self.src_def is not None and self.dst_def is None
 
     def is_temp(self):
-        """Is this a temp value, defined only in the dst pattern?"""
         # type: () -> bool
-        return not self.src_def and self.dst_def
+        """Is this a temp value, defined only in the dst pattern?"""
+        return self.src_def is None and self.dst_def is not None
 
     def get_typevar(self):
         # type: () -> TypeVar

--- a/lib/cretonne/meta/cdsl/formats.py
+++ b/lib/cretonne/meta/cdsl/formats.py
@@ -6,7 +6,7 @@ from .operands import Operand  # noqa
 # The typing module is only required by mypy, and we don't use these imports
 # outside type comments.
 try:
-    from typing import Tuple, Union, Any, Sequence, Iterable  # noqa
+    from typing import Dict, List, Tuple, Union, Any, Sequence, Iterable  # noqa
 except ImportError:
     pass
 

--- a/lib/cretonne/meta/cdsl/instructions.py
+++ b/lib/cretonne/meta/cdsl/instructions.py
@@ -6,7 +6,7 @@ from .operands import Operand
 from .formats import InstructionFormat
 
 try:
-    from typing import Union, Sequence
+    from typing import Union, Sequence, List  # noqa
     # List of operands for ins/outs:
     OpList = Union[Sequence[Operand], Operand]
     MaybeBoundInst = Union['Instruction', 'BoundInstruction']

--- a/lib/cretonne/meta/cdsl/isa.py
+++ b/lib/cretonne/meta/cdsl/isa.py
@@ -6,7 +6,7 @@ from .registers import RegClass, Register
 # The typing module is only required by mypy, and we don't use these imports
 # outside type comments.
 try:
-    from typing import Tuple, Union, Any, Iterable, Sequence, TYPE_CHECKING  # noqa
+    from typing import Tuple, Union, Any, Iterable, Sequence, List, Set, TYPE_CHECKING  # noqa
     from .instructions import MaybeBoundInst, InstructionGroup, InstructionFormat  # noqa
     from .predicates import Predicate, FieldPredicate  # noqa
     from .settings import SettingGroup  # noqa

--- a/lib/cretonne/meta/cdsl/registers.py
+++ b/lib/cretonne/meta/cdsl/registers.py
@@ -26,7 +26,7 @@ from . import is_power_of_two, next_power_of_two
 
 
 try:
-    from typing import Sequence, Tuple  # noqa
+    from typing import Sequence, Tuple, List, Dict  # noqa
     from .isa import TargetISA  # noqa
     # A tuple uniquely identifying a register class inside a register bank.
     # (count, width, start)

--- a/lib/cretonne/meta/cdsl/types.py
+++ b/lib/cretonne/meta/cdsl/types.py
@@ -2,6 +2,11 @@
 from __future__ import absolute_import
 import math
 
+try:
+    from typing import Dict, List  # noqa
+except ImportError:
+    pass
+
 
 # ValueType instances (i8, i32, ...) are provided in the cretonne.types module.
 class ValueType(object):

--- a/lib/cretonne/meta/cdsl/xform.py
+++ b/lib/cretonne/meta/cdsl/xform.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from .ast import Def, Var, Apply
 
 try:
-    from typing import Union, Iterator, Sequence, Iterable  # noqa
+    from typing import Union, Iterator, Sequence, Iterable, List, Dict  # noqa
     from .ast import Expr  # noqa
     DefApply = Union[Def, Apply]
 except ImportError:

--- a/lib/cretonne/meta/gen_instr.py
+++ b/lib/cretonne/meta/gen_instr.py
@@ -14,6 +14,13 @@ from cdsl.instructions import Instruction  # noqa
 from cdsl.operands import Operand  # noqa
 from cdsl.typevar import TypeVar  # noqa
 
+# The typing module is only required by mypy, and we don't use these imports
+# outside type comments.
+try:
+    from typing import List  # noqa
+except ImportError:
+    pass
+
 
 def gen_formats(fmt):
     # type: (srcgen.Formatter) -> None

--- a/lib/cretonne/meta/gen_registers.py
+++ b/lib/cretonne/meta/gen_registers.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 import srcgen
 
 try:
-    from typing import Sequence  # noqa
+    from typing import Sequence, List  # noqa
     from cdsl.isa import TargetISA  # noqa
     from cdsl.registers import RegBank, RegClass  # noqa
 except ImportError:

--- a/lib/cretonne/meta/isa/__init__.py
+++ b/lib/cretonne/meta/isa/__init__.py
@@ -9,6 +9,11 @@ from __future__ import absolute_import
 from cdsl.isa import TargetISA  # noqa
 from . import riscv, intel, arm32, arm64
 
+try:
+    from typing import List  # noqa
+except ImportError:
+    pass
+
 
 def all_isas():
     # type: () -> List[TargetISA]

--- a/lib/cretonne/meta/srcgen.py
+++ b/lib/cretonne/meta/srcgen.py
@@ -11,7 +11,7 @@ import os
 import re
 
 try:
-    from typing import Any  # noqa
+    from typing import Any, List  # noqa
 except ImportError:
     pass
 

--- a/lib/reader/src/isaspec.rs
+++ b/lib/reader/src/isaspec.rs
@@ -22,6 +22,18 @@ pub enum IsaSpec {
     Some(Vec<Box<TargetIsa>>),
 }
 
+impl IsaSpec {
+    /// If the `IsaSpec` contains exactly 1 `TargetIsa` we return a reference to it
+    pub fn unique_isa(&self) -> Option<&TargetIsa> {
+        if let &IsaSpec::Some(ref isa_vec) = self {
+            if isa_vec.len() == 1 {
+                return Some(&*isa_vec[0]);
+            }
+        }
+        None
+    }
+}
+
 /// Parse an iterator of command line options and apply them to `config`.
 pub fn parse_options<'a, I>(iter: I, config: &mut Configurable, loc: &Location) -> Result<()>
     where I: Iterator<Item = &'a str>


### PR DESCRIPTION
Currently only using result_registers to verify that the same number of result registers are specified as there are results, and then throwing it away. I can see they should be parsed with TargetIsa::register_info().parse_regunit() but where then should they be stored?

I'm not sure about adding find_recipe_index to TargetIsa, it seems like something that implementations would want to implement as a hashtable lookup if there are lots of recipes, so maybe is suitable in the trait?

Can we have encodings without registers and registers without encodings? Which of the following definitions would be correct?
	encoding ::= "[" (encoding_literal | "-") , (result_registers | "-") "]"
or
	encoding ::= "[" encoding_literal, result_registers "]" |
	             "[-,-]"