### PR TITLE
Parse ValueLoc for each SSA value result of instructions

### DIFF
--- a/filetests/parser/instruction_encoding.cton
+++ b/filetests/parser/instruction_encoding.cton
@@ -15,11 +15,10 @@ ebb1(v0: i32, v1: i32):
 }
 ; sameln: function foo(i32, i32) {
 ; nextln: $ebb1($v0: i32, $v1: i32):
-; nextln:     [-]$WS $v2 = iadd $v0, $v1
+; nextln:     [-,-]$WS $v2 = iadd $v0, $v1
 ; nextln:     [-]$WS trap
-; nextln:     [R#1234]$WS $v6, $v7 = iadd_cout $v2, $v0
-; TODO Add the full encoding information available: instruction recipe name and architectural registers if specified
-; nextln:     [Rshamt#beef]$WS $v8 = ishl_imm $v6, 2
-; nextln:     [-]$WS $v9 = iadd $v8, $v7
+; nextln:     [R#1234,%x5,%x11]$WS $v6, $v7 = iadd_cout $v2, $v0
+; nextln:     [Rshamt#beef,%x25]$WS $v8 = ishl_imm $v6, 2
+; nextln:     [-,-]$WS $v9 = iadd $v8, $v7
 ; nextln:     [Iret#05]$WS return $v0, $v8
 ; nextln: }


### PR DESCRIPTION
Issue #24

Some work left to do, and I am currently trying to work out a bug; it seems I am not currently filling in the `function.locations` `EntityMap` properly, as some tests crash with an out-of-bounds access in `write.rs:189:write_instruction()` when trying to stringify a function.

I also want to do some more cleanup, such as possibly moving the code that fills out `function.locations` at the end of `Parser::parse_instruction` into `Parser::add_values`.

I was also going to look at parsing value locations of function arguments (issue #49), but maybe this should be another pull request.