### PR TITLE
Use write! in utility code, rather than calling write_function directly.

### DIFF
--- a/src/filetest/legalizer.rs
+++ b/src/filetest/legalizer.rs
@@ -4,7 +4,7 @@
 //! the result to filecheck.
 
 use std::borrow::Cow;
-use cretonne::{self};
+use cretonne;
 use cretonne::ir::Function;
 use cton_reader::TestCommand;
 use filetest::subtest::{SubTest, Context, Result, run_filecheck};

--- a/src/filetest/legalizer.rs
+++ b/src/filetest/legalizer.rs
@@ -4,10 +4,11 @@
 //! the result to filecheck.
 
 use std::borrow::Cow;
-use cretonne::{self, write_function};
+use cretonne::{self};
 use cretonne::ir::Function;
 use cton_reader::TestCommand;
 use filetest::subtest::{SubTest, Context, Result, run_filecheck};
+use std::fmt::Write;
 use utils::pretty_error;
 
 struct TestLegalizer;
@@ -45,7 +46,7 @@ impl SubTest for TestLegalizer {
             .map_err(|e| pretty_error(&comp_ctx.func, e))?;
 
         let mut text = String::new();
-        write_function(&mut text, &comp_ctx.func, Some(isa))
+        write!(&mut text, "{}", &comp_ctx.func.display(Some(isa)))
             .map_err(|e| e.to_string())?;
         run_filecheck(&text, context)
     }

--- a/src/filetest/regalloc.rs
+++ b/src/filetest/regalloc.rs
@@ -6,10 +6,11 @@
 //! The resulting function is sent to `filecheck`.
 
 use cretonne::ir::Function;
-use cretonne::{self, write_function};
+use cretonne::{self};
 use cton_reader::TestCommand;
 use filetest::subtest::{SubTest, Context, Result, run_filecheck};
 use std::borrow::Cow;
+use std::fmt::Write;
 use utils::pretty_error;
 
 struct TestRegalloc;
@@ -53,7 +54,7 @@ impl SubTest for TestRegalloc {
             .map_err(|e| pretty_error(&comp_ctx.func, e))?;
 
         let mut text = String::new();
-        write_function(&mut text, &comp_ctx.func, Some(isa))
+        write!(&mut text, "{}", &comp_ctx.func.display(Some(isa)))
             .map_err(|e| e.to_string())?;
         run_filecheck(&text, context)
     }

--- a/src/filetest/regalloc.rs
+++ b/src/filetest/regalloc.rs
@@ -6,7 +6,7 @@
 //! The resulting function is sent to `filecheck`.
 
 use cretonne::ir::Function;
-use cretonne::{self};
+use cretonne;
 use cton_reader::TestCommand;
 use filetest::subtest::{SubTest, Context, Result, run_filecheck};
 use std::borrow::Cow;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 //! Utility functions.
 
 use cretonne::ir::entities::AnyEntity;
-use cretonne::{ir, verifier, write_function};
+use cretonne::{ir, verifier};
 use cretonne::result::CtonError;
 use std::fmt::Write;
 use std::fs::File;
@@ -42,7 +42,7 @@ pub fn pretty_verifier_error(func: &ir::Function, err: verifier::Error) -> Strin
         }
         _ => msg.push('\n'),
     }
-    write_function(&mut msg, func, None).unwrap();
+    write!(msg, "{}", func).unwrap();
     msg
 }
 


### PR DESCRIPTION
This changes uses of `write_function` in utility code to use the more general `write!` interface, which ends up calling `write_function` internally. It seems to make sense for utility code to use the more general interface, but feel free to close this if not.