### PR TITLE
Update rustfmt to 0.8.4

### DIFF
--- a/check-rustfmt.sh
+++ b/check-rustfmt.sh
@@ -15,7 +15,7 @@
 # With the --install option, also tries to install the right version.
 
 # This version should always be bumped to the newest version available.
-VERS="0.8.3"
+VERS="0.8.4"
 
 if cargo install --list | grep -q "^rustfmt v$VERS"; then
     exit 0

--- a/lib/cretonne/src/binemit/relaxation.rs
+++ b/lib/cretonne/src/binemit/relaxation.rs
@@ -97,9 +97,7 @@ pub fn relax_branches(func: &mut Function, isa: &TargetIsa) {
 /// existing `fallthrough` instructions are correct.
 fn fallthroughs(func: &mut Function) {
     for (ebb, succ) in func.layout.ebbs().adjacent_pairs() {
-        let term = func.layout
-            .last_inst(ebb)
-            .expect("EBB has no terminator.");
+        let term = func.layout.last_inst(ebb).expect("EBB has no terminator.");
         if let InstructionData::Jump {
                    ref mut opcode,
                    destination,

--- a/lib/cretonne/src/dominator_tree.rs
+++ b/lib/cretonne/src/dominator_tree.rs
@@ -88,8 +88,7 @@ impl DominatorTree {
         // Run a finger up the dominator tree from b until we see a.
         // Do nothing if b is unreachable.
         while rpo_a < self.nodes[ebb_b].rpo_number {
-            b = self.idom(ebb_b)
-                .expect("Shouldn't meet unreachable here.");
+            b = self.idom(ebb_b).expect("Shouldn't meet unreachable here.");
             ebb_b = layout.inst_ebb(b).expect("Dominator got removed.");
         }
 

--- a/lib/cretonne/src/entity_list.rs
+++ b/lib/cretonne/src/entity_list.rs
@@ -135,9 +135,7 @@ impl<T: EntityRef> ListPool<T> {
         // The `wrapping_sub` handles the special case 0, which is the empty list. This way, the
         // cost of the bounds check that we have to pay anyway is co-opted to handle the special
         // case of the empty list.
-        self.data
-            .get(idx.wrapping_sub(1))
-            .map(|len| len.index())
+        self.data.get(idx.wrapping_sub(1)).map(|len| len.index())
     }
 
     /// Allocate a storage block with a size given by `sclass`.

--- a/lib/cretonne/src/ir/builder.rs
+++ b/lib/cretonne/src/ir/builder.rs
@@ -132,8 +132,7 @@ impl<'c, 'fc, 'fd, Array> InstBuilderBase<'fd> for InsertReuseBuilder<'c, 'fc, '
         let inst = self.dfg.make_inst(data);
         // Make an `Interator<Item = Option<Value>>`.
         let ru = self.reuse.as_ref().iter().cloned();
-        self.dfg
-            .make_inst_results_reusing(inst, ctrl_typevar, ru);
+        self.dfg.make_inst_results_reusing(inst, ctrl_typevar, ru);
         self.pos.insert_inst(inst);
         (inst, self.dfg)
     }

--- a/lib/cretonne/src/ir/dfg.rs
+++ b/lib/cretonne/src/ir/dfg.rs
@@ -316,37 +316,25 @@ impl DataFlowGraph {
 
     /// Get the fixed value arguments on `inst` as a slice.
     pub fn inst_fixed_args(&self, inst: Inst) -> &[Value] {
-        let fixed_args = self[inst]
-            .opcode()
-            .constraints()
-            .fixed_value_arguments();
+        let fixed_args = self[inst].opcode().constraints().fixed_value_arguments();
         &self.inst_args(inst)[..fixed_args]
     }
 
     /// Get the fixed value arguments on `inst` as a mutable slice.
     pub fn inst_fixed_args_mut(&mut self, inst: Inst) -> &mut [Value] {
-        let fixed_args = self[inst]
-            .opcode()
-            .constraints()
-            .fixed_value_arguments();
+        let fixed_args = self[inst].opcode().constraints().fixed_value_arguments();
         &mut self.inst_args_mut(inst)[..fixed_args]
     }
 
     /// Get the variable value arguments on `inst` as a slice.
     pub fn inst_variable_args(&self, inst: Inst) -> &[Value] {
-        let fixed_args = self[inst]
-            .opcode()
-            .constraints()
-            .fixed_value_arguments();
+        let fixed_args = self[inst].opcode().constraints().fixed_value_arguments();
         &self.inst_args(inst)[fixed_args..]
     }
 
     /// Get the variable value arguments on `inst` as a mutable slice.
     pub fn inst_variable_args_mut(&mut self, inst: Inst) -> &mut [Value] {
-        let fixed_args = self[inst]
-            .opcode()
-            .constraints()
-            .fixed_value_arguments();
+        let fixed_args = self[inst].opcode().constraints().fixed_value_arguments();
         &mut self.inst_args_mut(inst)[fixed_args..]
     }
 

--- a/lib/cretonne/src/ir/instructions.rs
+++ b/lib/cretonne/src/ir/instructions.rs
@@ -288,20 +288,20 @@ impl InstructionData {
     pub fn analyze_branch<'a>(&'a self, pool: &'a ValueListPool) -> BranchInfo<'a> {
         match self {
             &InstructionData::Jump {
-                 destination,
-                 ref args,
-                 ..
-             } => BranchInfo::SingleDest(destination, &args.as_slice(pool)),
+                destination,
+                ref args,
+                ..
+            } => BranchInfo::SingleDest(destination, &args.as_slice(pool)),
             &InstructionData::Branch {
-                 destination,
-                 ref args,
-                 ..
-             } => BranchInfo::SingleDest(destination, &args.as_slice(pool)[1..]),
+                destination,
+                ref args,
+                ..
+            } => BranchInfo::SingleDest(destination, &args.as_slice(pool)[1..]),
             &InstructionData::BranchIcmp {
-                 destination,
-                 ref args,
-                 ..
-             } => BranchInfo::SingleDest(destination, &args.as_slice(pool)[2..]),
+                destination,
+                ref args,
+                ..
+            } => BranchInfo::SingleDest(destination, &args.as_slice(pool)[2..]),
             &InstructionData::BranchTable { table, .. } => BranchInfo::Table(table),
             _ => BranchInfo::NotABranch,
         }
@@ -595,11 +595,7 @@ impl OperandConstraint {
             Same => Bound(ctrl_type),
             LaneOf => Bound(ctrl_type.lane_type()),
             AsBool => Bound(ctrl_type.as_bool()),
-            HalfWidth => {
-                Bound(ctrl_type
-                          .half_width()
-                          .expect("invalid type for half_width"))
-            }
+            HalfWidth => Bound(ctrl_type.half_width().expect("invalid type for half_width")),
             DoubleWidth => {
                 Bound(ctrl_type
                           .double_width()

--- a/lib/cretonne/src/ir/layout.rs
+++ b/lib/cretonne/src/ir/layout.rs
@@ -467,8 +467,7 @@ impl Layout {
 
     /// Remove `inst` from the layout.
     pub fn remove_inst(&mut self, inst: Inst) {
-        let ebb = self.inst_ebb(inst)
-            .expect("Instruction already removed.");
+        let ebb = self.inst_ebb(inst).expect("Instruction already removed.");
         // Clear the `inst` node and extract links.
         let prev;
         let next;

--- a/lib/cretonne/src/isa/encoding.rs
+++ b/lib/cretonne/src/isa/encoding.rs
@@ -130,8 +130,6 @@ impl EncInfo {
     ///
     /// This will never return `None` for a legal branch encoding.
     pub fn branch_range(&self, enc: Encoding) -> Option<BranchRange> {
-        self.sizing
-            .get(enc.recipe())
-            .and_then(|s| s.branch_range)
+        self.sizing.get(enc.recipe()).and_then(|s| s.branch_range)
     }
 }

--- a/lib/cretonne/src/iterators.rs
+++ b/lib/cretonne/src/iterators.rs
@@ -65,17 +65,9 @@ mod tests {
                        .adjacent_pairs()
                        .collect::<Vec<_>>(),
                    vec![(2, 3), (3, 4)]);
-        assert_eq!([3, 4]
-                       .iter()
-                       .cloned()
-                       .adjacent_pairs()
-                       .collect::<Vec<_>>(),
+        assert_eq!([3, 4].iter().cloned().adjacent_pairs().collect::<Vec<_>>(),
                    vec![(3, 4)]);
-        assert_eq!([4]
-                       .iter()
-                       .cloned()
-                       .adjacent_pairs()
-                       .collect::<Vec<_>>(),
+        assert_eq!([4].iter().cloned().adjacent_pairs().collect::<Vec<_>>(),
                    vec![]);
         assert_eq!([]
                        .iter()

--- a/lib/cretonne/src/legalizer/boundary.rs
+++ b/lib/cretonne/src/legalizer/boundary.rs
@@ -251,9 +251,7 @@ fn convert_from_abi<GetArg>(dfg: &mut DataFlowGraph,
             assert!(!ty.is_int());
             let abi_ty = Type::int(ty.bits()).expect("Invalid type for conversion");
             let arg = convert_from_abi(dfg, pos, abi_ty, None, get_arg);
-            dfg.ins(pos)
-                .with_results([into_result])
-                .bitcast(ty, arg)
+            dfg.ins(pos).with_results([into_result]).bitcast(ty, arg)
         }
         // ABI argument is a sign-extended version of the value we want.
         ValueConversion::Sext(abi_ty) => {
@@ -261,18 +259,14 @@ fn convert_from_abi<GetArg>(dfg: &mut DataFlowGraph,
             // TODO: Currently, we don't take advantage of the ABI argument being sign-extended.
             // We could insert an `assert_sreduce` which would fold with a following `sextend` of
             // this value.
-            dfg.ins(pos)
-                .with_results([into_result])
-                .ireduce(ty, arg)
+            dfg.ins(pos).with_results([into_result]).ireduce(ty, arg)
         }
         ValueConversion::Uext(abi_ty) => {
             let arg = convert_from_abi(dfg, pos, abi_ty, None, get_arg);
             // TODO: Currently, we don't take advantage of the ABI argument being sign-extended.
             // We could insert an `assert_ureduce` which would fold with a following `uextend` of
             // this value.
-            dfg.ins(pos)
-                .with_results([into_result])
-                .ireduce(ty, arg)
+            dfg.ins(pos).with_results([into_result]).ireduce(ty, arg)
         }
     }
 }

--- a/lib/cretonne/src/regalloc/allocatable_set.rs
+++ b/lib/cretonne/src/regalloc/allocatable_set.rs
@@ -137,21 +137,21 @@ mod tests {
 
     // Register classes for testing.
     const GPR: RegClass = &RegClassData {
-                               name: "GPR",
-                               index: 0,
-                               width: 1,
-                               first: 28,
-                               subclasses: 0,
-                               mask: [0xf0000000, 0x0000000f, 0],
-                           };
+        name: "GPR",
+        index: 0,
+        width: 1,
+        first: 28,
+        subclasses: 0,
+        mask: [0xf0000000, 0x0000000f, 0],
+    };
     const DPR: RegClass = &RegClassData {
-                               name: "DPR",
-                               index: 0,
-                               width: 2,
-                               first: 28,
-                               subclasses: 0,
-                               mask: [0x50000000, 0x0000000a, 0],
-                           };
+        name: "DPR",
+        index: 0,
+        width: 2,
+        first: 28,
+        subclasses: 0,
+        mask: [0x50000000, 0x0000000a, 0],
+    };
 
     #[test]
     fn put_and_take() {

--- a/lib/cretonne/src/regalloc/diversion.rs
+++ b/lib/cretonne/src/regalloc/diversion.rs
@@ -100,10 +100,10 @@ mod tests {
         divs.regmove(v1, 10, 12);
         assert_eq!(divs.diversion(v1),
                    Some(&Diversion {
-                             value: v1,
-                             from: 10,
-                             to: 12,
-                         }));
+                            value: v1,
+                            from: 10,
+                            to: 12,
+                        }));
         assert_eq!(divs.diversion(v2), None);
 
         divs.regmove(v1, 12, 11);

--- a/lib/cretonne/src/regalloc/solver.rs
+++ b/lib/cretonne/src/regalloc/solver.rs
@@ -414,8 +414,7 @@ impl Solver {
         if self.inputs_done {
             self.regs_out.free(constraint, from);
         }
-        self.vars
-            .push(Variable::new_live(value, constraint, from));
+        self.vars.push(Variable::new_live(value, constraint, from));
     }
 
     /// Check for conflicts between fixed input assignments and existing live values.

--- a/lib/cretonne/src/verifier/mod.rs
+++ b/lib/cretonne/src/verifier/mod.rs
@@ -234,20 +234,20 @@ impl<'a> Verifier<'a> {
                 self.verify_value_list(inst, args)?;
             }
             &Jump {
-                 destination,
-                 ref args,
-                 ..
-             } |
+                destination,
+                ref args,
+                ..
+            } |
             &Branch {
-                 destination,
-                 ref args,
-                 ..
-             } |
+                destination,
+                ref args,
+                ..
+            } |
             &BranchIcmp {
-                 destination,
-                 ref args,
-                 ..
-             } => {
+                destination,
+                ref args,
+                ..
+            } => {
                 self.verify_ebb(inst, destination)?;
                 self.verify_value_list(inst, args)?;
             }
@@ -381,8 +381,7 @@ impl<'a> Verifier<'a> {
                                 ebb);
                 }
                 // The defining EBB dominates the instruction using this value.
-                if !self.domtree
-                        .ebb_dominates(ebb, loc_inst, &self.func.layout) {
+                if !self.domtree.ebb_dominates(ebb, loc_inst, &self.func.layout) {
                     return err!(loc_inst, "uses value arg from non-dominating {}", ebb);
                 }
             }
@@ -639,10 +638,7 @@ impl<'a> Verifier<'a> {
                 return err!(ebb, "cfg had unexpected successor(s) {:?}", excess_succs);
             }
 
-            expected_preds.extend(self.cfg
-                                      .get_predecessors(ebb)
-                                      .iter()
-                                      .map(|&(_, inst)| inst));
+            expected_preds.extend(self.cfg.get_predecessors(ebb).iter().map(|&(_, inst)| inst));
             got_preds.extend(cfg.get_predecessors(ebb).iter().map(|&(_, inst)| inst));
 
             let missing_preds: Vec<Inst> = expected_preds.difference(&got_preds).cloned().collect();

--- a/lib/filecheck/src/checker.rs
+++ b/lib/filecheck/src/checker.rs
@@ -416,11 +416,9 @@ mod tests {
                    Ok(true));
         assert_eq!(b.directive("regex: X = tommy").map_err(e2s),
                    Err("expected '=' after variable 'X' in regex: X = tommy".to_string()));
-        assert_eq!(b.directive("[arm]not:    patt $x $(y) here")
-                       .map_err(e2s),
+        assert_eq!(b.directive("[arm]not:    patt $x $(y) here").map_err(e2s),
                    Ok(true));
-        assert_eq!(b.directive("[x86]sameln: $x $(y=[^]]*) there")
-                       .map_err(e2s),
+        assert_eq!(b.directive("[x86]sameln: $x $(y=[^]]*) there").map_err(e2s),
                    Ok(true));
         // Windows line ending sneaking in.
         assert_eq!(b.directive("regex: Y=foo\r").map_err(e2s), Ok(true));

--- a/lib/reader/src/lexer.rs
+++ b/lib/reader/src/lexer.rs
@@ -296,7 +296,7 @@ impl<'a> Lexer<'a> {
         token(split_entity_name(text)
                   .and_then(|(prefix, number)| {
                                 Self::numbered_entity(prefix, number)
-                          .or_else(|| Self::value_type(text, prefix, number))
+                                    .or_else(|| Self::value_type(text, prefix, number))
                             })
                   .unwrap_or(Token::Identifier(text)),
               loc)
@@ -413,14 +413,14 @@ impl<'a> Lexer<'a> {
                        Some('%') => Some(self.scan_name()),
                        Some('#') => Some(self.scan_hex_sequence()),
                        Some(ch) if ch.is_whitespace() => {
-                self.next_ch();
-                continue;
-            }
+                           self.next_ch();
+                           continue;
+                       }
                        _ => {
-                // Skip invalid char, return error.
-                self.next_ch();
-                Some(error(Error::InvalidChar, loc))
-            }
+                           // Skip invalid char, return error.
+                           self.next_ch();
+                           Some(error(Error::InvalidChar, loc))
+                       }
                    };
         }
     }

--- a/src/filetest/concurrent.rs
+++ b/src/filetest/concurrent.rs
@@ -119,9 +119,7 @@ fn worker_thread(thread_num: usize,
 
                 // Tell them we're starting this job.
                 // The receiver should always be present for this as long as we have jobs.
-                replies
-                    .send(Reply::Starting { jobid, thread_num })
-                    .unwrap();
+                replies.send(Reply::Starting { jobid, thread_num }).unwrap();
 
                 let result = catch_unwind(|| runone::run(path.as_path())).unwrap_or_else(|e| {
                     // The test panicked, leaving us a `Box<Any>`.

--- a/src/filetest/runner.rs
+++ b/src/filetest/runner.rs
@@ -207,9 +207,7 @@ impl TestRunner {
         }
 
         // Check for any asynchronous replies without blocking.
-        while let Some(reply) = self.threads
-                  .as_mut()
-                  .and_then(ConcurrentRunner::try_get) {
+        while let Some(reply) = self.threads.as_mut().and_then(ConcurrentRunner::try_get) {
             self.handle_reply(reply);
         }
     }


### PR DESCRIPTION
I was just looking around and saw that a new version of rustfmt had been released. Here's the result of updating the check-format script and run the format-all script.

I noticed it sometimes wrapped a few lines into one, which makes things slightly harder to read in some places. Are there any tweaks you'd like me to do in addition to the raw output of format-all?