### PR TITLE
Tc

### DIFF
--- a/lib/cretonne/meta/cdsl/instructions.py
+++ b/lib/cretonne/meta/cdsl/instructions.py
@@ -189,6 +189,7 @@ class Instruction(object):
                 if tv is tv.free_typevar():
                     self.other_typevars = self._verify_ctrl_typevar(tv)
                     self.ctrl_typevar = tv
+                    self.ctrl_typevar_ind = opnum
                     self.use_typevar_operand = True
             except RuntimeError as e:
                 typevar_error = e
@@ -203,10 +204,29 @@ class Instruction(object):
                     raise RuntimeError(
                             "typevar_operand must be a free type variable")
             tv = self.outs[0].typevar
+            self.ctrl_typevar_ind = -1
             if tv is not tv.free_typevar():
                 raise RuntimeError("first result must be a free type variable")
             self.other_typevars = self._verify_ctrl_typevar(tv)
             self.ctrl_typevar = tv
+
+    def get_ctrl_typevar_ind(self):
+        # type: (Instruction) -> Tuple[bool, int]
+        """
+        If this Instruction doesn't have a control TV return None.
+        Otherwsire return a (is_arg, index) tuple where:
+            - is_arg is True if the control TV is one of the arguments and
+              False if its a return
+            - index is the index of the argument/return which has the control
+              TV
+        """
+        if (not hasattr(self, "ctrl_typevar_ind")):
+            return None
+
+        if (self.ctrl_typevar_ind == -1):
+            return (False, 0)
+        else:
+            return (True, self.ctrl_typevar_ind)
 
     def _verify_ctrl_typevar(self, ctrl_typevar):
         # type: (TypeVar) -> List[TypeVar]

--- a/lib/cretonne/meta/cdsl/instructions.py
+++ b/lib/cretonne/meta/cdsl/instructions.py
@@ -189,7 +189,6 @@ class Instruction(object):
                 if tv is tv.free_typevar():
                     self.other_typevars = self._verify_ctrl_typevar(tv)
                     self.ctrl_typevar = tv
-                    self.ctrl_typevar_ind = opnum
                     self.use_typevar_operand = True
             except RuntimeError as e:
                 typevar_error = e
@@ -204,29 +203,10 @@ class Instruction(object):
                     raise RuntimeError(
                             "typevar_operand must be a free type variable")
             tv = self.outs[0].typevar
-            self.ctrl_typevar_ind = -1
             if tv is not tv.free_typevar():
                 raise RuntimeError("first result must be a free type variable")
             self.other_typevars = self._verify_ctrl_typevar(tv)
             self.ctrl_typevar = tv
-
-    def get_ctrl_typevar_ind(self):
-        # type: (Instruction) -> Tuple[bool, int]
-        """
-        If this Instruction doesn't have a control TV return None.
-        Otherwsire return a (is_arg, index) tuple where:
-            - is_arg is True if the control TV is one of the arguments and
-              False if its a return
-            - index is the index of the argument/return which has the control
-              TV
-        """
-        if (not hasattr(self, "ctrl_typevar_ind")):
-            return None
-
-        if (self.ctrl_typevar_ind == -1):
-            return (False, 0)
-        else:
-            return (True, self.ctrl_typevar_ind)
 
     def _verify_ctrl_typevar(self, ctrl_typevar):
         # type: (TypeVar) -> List[TypeVar]

--- a/lib/cretonne/meta/cdsl/tc.py
+++ b/lib/cretonne/meta/cdsl/tc.py
@@ -169,6 +169,7 @@ class TCDisagree(TCError): # noqa
 
 
 def normalize_tv(tv):
+    # type: (TypeVar) -> TypeVar
     """
     Normalize a (potentially derived) TV using the following rules:
         - collapse SAMEAS
@@ -182,7 +183,6 @@ def normalize_tv(tv):
         {HALF,DOUBLE}WIDTH({DOUBLE,HALF}WIDTH(base)) -> base
         {HALF,DOUBLE}VECTOR({DOUBLE,HALF}VECTOR(base)) -> base
     """
-    # type: (TypeVar) -> TypeVar
     vector_derives = [TypeVar.HALFVECTOR, TypeVar.DOUBLEVECTOR]
     width_derives = [TypeVar.HALFWIDTH, TypeVar.DOUBLEWIDTH]
 
@@ -225,10 +225,10 @@ def _mk_loc(line_loc, arg_loc):  # noqa
 
 
 def subtype(actual_typ, formal_typ):
+    # type: (TypeVar, TypeVar) -> bool
     """
     Check whether actual_typ's typeset is a subest of formal_ty's.
     """
-    # type: (TypeVar, TypeVar) -> bool
     return actual_typ.get_typeset().is_subset(formal_typ.get_typeset())
 
 

--- a/lib/cretonne/meta/cdsl/tc.py
+++ b/lib/cretonne/meta/cdsl/tc.py
@@ -1,0 +1,228 @@
+from .typevar import TypeVar
+from .ast import Var
+
+try:
+    from typing import Dict, List, Tuple, TypeVar as MTypeVar
+    from typing import Iterator, TYPE_CHECKING, cast, Set # noqa
+    if TYPE_CHECKING:
+        from srcgen import Formatter # noqa
+        from .xform import Rtl # noqa
+        from .instructions import Instruction # noqa
+        from .ast import Expr, Def # noqa
+        A = MTypeVar("A")
+        B = MTypeVar("B")
+        ErrLoc = Tuple[Rtl, int, bool, int]
+        TypeMap = Dict[TypeVar, TypeVar]
+        TypeEnv = Dict[Var, TypeVar]
+except ImportError:
+    pass
+
+
+def azip(l1, l2):
+    # type: (List[A], List[B]) -> Iterator[Tuple[A,B]]
+    assert len(l1) == len(l2)
+    return zip(l1, l2)
+
+
+def resolve(tv, m):
+    # type: (TypeVar, TypeMap) -> TypeVar
+    while tv in m:
+        tv1 = m[tv]
+        assert tv != tv1
+        tv = tv1
+
+    if tv.is_derived:
+        tv = TypeVar.derived(resolve(tv.base, m), tv.derived_func)
+
+    return tv
+
+
+def lookup(inst, defs, args):
+    # type: (Instruction, List[A], List[A]) -> Tuple[TypeVar, A] # noqa
+    (is_arg, idx) = inst.get_ctrl_typevar_ind()
+    if is_arg:
+        return (inst.ins[idx].typevar, args[idx])
+    else:
+        return (inst.outs[idx].typevar, defs[idx])
+
+
+def subst(tv, m):
+    # type: (TypeVar, TypeMap) -> TypeVar
+    if tv in m:
+        return m[tv]
+    elif tv.is_derived:
+        return TypeVar.derived(subst(tv.base, m), tv.derived_func)
+    else:
+        return tv
+
+
+class TCError(Exception):
+    def __init__(self, loc):
+        # type: (ErrLoc) -> None
+        super(TCError, self).__init__()
+        self.loc = loc
+
+    def set_loc(self, rtl, ln, is_arg, idx):
+        # type: (TCError, Rtl, int, bool, int) -> None
+        self.loc = (rtl, ln, is_arg, idx)
+
+    def __repr__(self):
+        # type: (TCError) -> str
+        (rtl, line_no, is_arg, idx) = self.loc
+        return "On line {} in {} no {} in '{}': ".format(
+                line_no, "arg" if is_arg else "result",
+                idx, rtl.rtl[line_no])
+
+    def __eq__(self, other):
+        # type: (TCError, object) -> bool
+        return isinstance(other, TCError) and \
+               self.__class__ == other.__class__ and \
+               self.loc == other.loc
+
+    def value(self):
+        # type: (TCError) -> Expr
+        (rtl, line_no, is_arg, idx) = self.loc
+        if is_arg:
+            return rtl.rtl[line_no].expr.args[idx]
+        else:
+            return rtl.rtl[line_no].defs[idx]
+
+
+class TCUndef(TCError):
+    def __repr__(self):
+        # type: (TCUndef) -> str
+        base = super(TCUndef, self).__repr__()
+        return base + "Undefined type for {}".format(self.value())
+
+
+class TCRedef(TCError):
+    def __repr__(self):
+        # type: (TCRedef) -> str
+        base = super(TCRedef, self).__repr__()
+        return base + "Redefining {}".format(self.value())
+
+
+class TCNotSubtype(TCError):
+    def __init__(self, loc, concr_type, formal_type):
+        # type: (ErrLoc, TypeVar, TypeVar) -> None
+        super(TCNotSubtype, self).__init__(loc)
+        self.concr_type = concr_type
+        self.formal_type = formal_type
+
+    def __repr__(self):
+        # type: (TCNotSubtype) -> str
+        base = super(TCNotSubtype, self).__repr__()
+        return base + "{} is not a subtype of {} for argument {}".format(
+                self.concr_type, self.formal_type, self.value())
+    # TODO: Override __eq__ to check inferred concrete and formal types
+    # equalities
+
+
+def _mk_loc(line_loc, arg_loc):
+    # type: (Tuple[Rtl, int], Tuple[bool, int]) -> ErrLoc
+    return (line_loc[0], line_loc[1], arg_loc[0], arg_loc[1])
+
+
+def tc_def(d, m, line_loc):
+    # type: (Def, TypeMap, Tuple[Rtl, int]) -> TypeMap
+    inst = d.expr.inst
+    defs = d.defs
+    args = cast(List[Var], d.expr.args)
+
+    formal_args = [x.typevar for x in inst.ins]
+    actual_args = [x.get_typevar() for x in args]
+
+    formal_defs = [x.typevar for x in inst.outs]
+    actual_defs = [x.get_typevar() for x in defs]
+    m1 = {}
+
+    # Iff inst.ctrl_typevar exists, inst is polymorphic
+    if hasattr(inst, "ctrl_typevar"):
+        # Determing which argument is the controling TV
+        arg_loc = inst.get_ctrl_typevar_ind()
+        # Get the formal and actual control TVs
+        formal_ctrl_tv, actual_ctrl_tv = \
+            lookup(inst, actual_defs, actual_args)
+
+        # If we don't have a type inferred/specified for
+        # the actual controlling TV then the input is
+        # underspecified
+        if (actual_ctrl_tv not in m):
+            raise TCUndef(_mk_loc(line_loc, arg_loc))
+
+        actual_ctrl_tv = resolve(actual_ctrl_tv, m)
+        assert not formal_ctrl_tv.is_derived
+
+        actual_ctrl_ts = actual_ctrl_tv.get_typeset()
+        formal_ctrl_ts = formal_ctrl_tv.get_typeset()
+
+        # The actual control variable's typeset violates
+        # the instruction signature
+        if not (actual_ctrl_ts.is_subset(formal_ctrl_ts)):
+            raise TCNotSubtype(_mk_loc(line_loc, arg_loc),
+                               actual_ctrl_tv,
+                               formal_ctrl_tv)
+
+        m1[formal_ctrl_tv] = actual_ctrl_tv
+    else:
+        assert not inst.is_polymorphic
+        actual_ctrl_tv = None
+
+    # print "Args: "
+    for (ind, (form, actual)) in enumerate(azip(formal_args, actual_args)):
+        arg_loc = (True, ind)
+        if (actual_ctrl_tv == actual):
+            continue
+
+        actual = resolve(actual, m)
+        form = resolve(subst(form, m1), m)
+
+        if (not actual.get_typeset().is_subset(form.get_typeset())):
+            raise TCNotSubtype(_mk_loc(line_loc, arg_loc), actual, form)
+
+    for (ind, (form, actual)) in enumerate(azip(formal_defs, actual_defs)):
+        arg_loc = (False, ind)
+        if actual_ctrl_tv == actual:
+            continue
+
+        form = resolve(subst(form, m1), m)
+        if actual in m:
+            raise TCRedef(_mk_loc(line_loc, arg_loc))
+        m[actual] = form
+
+    return m
+
+
+def tc_rtl(r, m):
+    # type: (Rtl, TypeMap) -> TypeMap
+    for ln, d in enumerate(r.rtl):
+        m = tc_def(d, m, (r, ln))
+
+    return m
+
+
+def to_TypeMap(t):
+    # type: (TypeEnv) -> TypeMap
+    return {k.get_typevar(): v for (k, v) in t.items()}
+
+
+def io_shape(r):
+    # type: (Rtl) -> Tuple[Set[Expr], Set[Expr], Set[Expr]]
+    inputs = set()  # type: Set[Expr]
+    input_ctrls = set()  # type: Set[Expr]
+    defs = set()  # type: Set[Expr]
+    for d in r.rtl:
+        inst = d.expr.inst
+        actual_uses = list(d.expr.args)  # type: List[Expr]
+        actual_defs = list(d.defs)  # type: List[Expr]
+
+        inputs = inputs.union(set(actual_uses).difference(defs))
+        if hasattr(inst, "ctrl_typevar"):
+            # Get the formal and actual control TVs
+            _, actual_ctrl = lookup(inst, actual_defs, actual_uses)
+            if actual_ctrl not in defs:
+                input_ctrls.add(actual_ctrl)
+
+        defs = defs.union(actual_defs)
+
+    return (inputs, input_ctrls, defs)

--- a/lib/cretonne/meta/cdsl/test_tc.py
+++ b/lib/cretonne/meta/cdsl/test_tc.py
@@ -93,6 +93,7 @@ class TestIOShape(TypeCheckingBaseTest):
         self.assertEqual(io_shape(r),
                          (set([self.v1, self.v2, self.v3]),  # Inputs
                           set([self.v2]),  # Control Vars
+                          set([]),  # Free Non-Derived TVs
                           set([self.v0])))  # Defs
 
     def test_double_split(self):
@@ -105,6 +106,7 @@ class TestIOShape(TypeCheckingBaseTest):
         self.assertEqual(io_shape(r),
                          (set([self.v1, self.v2, self.v3]),  # Inputs
                           set([self.v2]),  # Control Vars
+                          set([]),  # Free Non-Derived TVs
                           set([self.v0, self.v4, self.v5, self.v6,
                                self.v7])))  # Defs
 
@@ -120,6 +122,7 @@ class TestIOShape(TypeCheckingBaseTest):
         self.assertEqual(io_shape(r),
                          (set([self.v1, self.v2, self.v3, self.vm1]),  # Inputs
                           set([self.v2]),  # Control Vars
+                          set([]),  # Free Non-Derived TVs
                           set([self.v0, self.v4, self.v5, self.v6,
                                self.v7, self.v8, self.v9])))  # Defs
 
@@ -133,6 +136,7 @@ class TestIOShape(TypeCheckingBaseTest):
         self.assertEqual(io_shape(r),
                          (set([self.imm0]),  # Inputs
                           set([self.v0]),  # Control Vars
+                          set([]),  # Free Non-Derived TVs
                           set([self.v0])))  # Defs
 
     def test_pattern4(self):
@@ -152,6 +156,7 @@ class TestIOShape(TypeCheckingBaseTest):
                          (set([self.imm0, self.v2, self.v3,
                                self.vm1]),  # Inputs
                           set([self.v2, self.v1]),  # Control Vars
+                          set([]),  # Free Non-Derived TVs
                           set([self.v1, self.v0, self.v4, self.v5, self.v6,
                                self.v7, self.v8, self.v9])))  # Defs
 
@@ -173,6 +178,7 @@ class TestIOShape(TypeCheckingBaseTest):
                          (set([self.imm0, self.v2, self.v3,
                                self.vm1]),  # Inputs
                           set([self.v2, self.v1, self.vm1]),  # Control Vars
+                          set([]),  # Free Non-Derived TVs
                           set([self.v1, self.v0, self.v4, self.v5, self.v6,
                                self.v7, self.v8, self.v9])))  # Defs
 
@@ -320,7 +326,7 @@ class TestTC(TypeCheckingBaseTest):
 
         self.runTC(r,
                    {},
-                   TCUnderspecified(r, set([self.v0, self.v1])))
+                   TCUnderspecified(r, set([self.v0])))
 
         self.runTC(r,
                    {self.v0: self.i16_32,
@@ -440,7 +446,7 @@ class TestTCXForm(TypeCheckingBaseTest):
 
         self.runTCXForm(x,
                         {},
-                        TCUnderspecified(x.src, set([self.v2, self.v3])))
+                        TCUnderspecified(x.src, set([self.v2])))
 
         self.runTCXForm(x,
                         {self.v2: iB, self.v3: self.b1},
@@ -449,6 +455,5 @@ class TestTCXForm(TypeCheckingBaseTest):
         self.runTCXForm(x,
                         {self.v2: iB,
                          self.v1: iB,
-                         self.v5: iB,
-                         self.v3: self.b1},
+                         self.v5: iB},
                         {})

--- a/lib/cretonne/meta/cdsl/test_tc.py
+++ b/lib/cretonne/meta/cdsl/test_tc.py
@@ -333,14 +333,14 @@ class TestTC(TypeCheckingBaseTest):
                     self.v4: self.IxN_nonscalar,
                     self.v5: self.IxN_nonscalar})
 
-        # This shouldn't typecheck. We should add unification and reject it.
+        # v0 and v3 are of types with unrelated width
         self.runTC(r,
                    {self.v0: self.IxN_nonscalar,
                     self.v1: self.IxN_nonscalar,
                     self.v3: TxN},
                    TCNotSubtype((r, 2, True, 0), None, None))
 
-        # And neither should this. Again add unification and reject it.
+        # v0 and v3 are of types with unrelated width
         self.runTC(r,
                    {self.v0: self.IxN_nonscalar,
                     self.v1: self.IxN2_nonscalar,

--- a/lib/cretonne/meta/cdsl/test_tc.py
+++ b/lib/cretonne/meta/cdsl/test_tc.py
@@ -3,8 +3,7 @@ from base.instructions import vselect, vsplit, vconcat, TxN, iconst, iadd,\
         uextend, sextend, Int, bint, Bool, iadd_cin, iB, b1
 from .typevar import TypeVar
 from .tc import tc_rtl, TCError, TCNotSubtype, io_shape, TCOverspecified,\
-    TCUnderspecified, tc_xform, TCDisagree, TCUnderconstrainedInput,\
-    TCRedef
+    TCUnderspecified, tc_xform, TCDisagree, TCRedef
 from .ast import Var
 from .xform import Rtl, XForm
 from unittest import TestCase
@@ -382,19 +381,6 @@ class TestTCXForm(TypeCheckingBaseTest):
         self.runTCXForm(x,
                         {self.v2: self.simd8_64},
                         TCDisagree(x, self.v0, None, None))
-
-    def test_trivial_unconstrained_input(self):
-        x = XForm(
-                Rtl(
-                    self.v4 << vconcat(self.v2, self.v3)
-                ),
-                Rtl(
-                    (self.v0, self.v1) << vsplit(self.v2)
-                ))
-
-        self.runTCXForm(x,
-                        {self.v2: self.simd8_64},
-                        TCUnderconstrainedInput(x, self.v3))
 
     def test_trivial_extra_dst(self):
         # Its not an error to have dest have extra outputs

--- a/lib/cretonne/meta/cdsl/test_tc.py
+++ b/lib/cretonne/meta/cdsl/test_tc.py
@@ -280,6 +280,24 @@ class TestTC(TypeCheckingBaseTest):
                    {self.v2: TxN, self.v1: TxN},
                    TCNotSubtype((r, 0, False, 0), None, None))
 
+    def test_vselect_imm_short(self):
+        r = Rtl(
+                self.v0 << iconst(self.imm0),
+                self.v2 << icmp(intcc.ne, self.v0, self.v1),
+                self.v5 << vselect(self.v2, self.v3, self.v4),
+        )
+        # This shouldn't typecheck... But we need constrainbts to be able to
+        # express this. And also unification
+        self.runTC(r,
+                   {self.v0: self.IxN_nonscalar,
+                    self.v3: TxN},
+                   {self.v0: self.IxN_nonscalar,
+                    self.v1: self.IxN_nonscalar,
+                    self.v2: self.IxN_nonscalar.as_bool(),
+                    self.v3: TxN,
+                    self.v4: TxN,
+                    self.v5: TxN})
+
     def test_vselect_imm(self):
         r = Rtl(
                 self.v0 << iconst(self.imm0),
@@ -320,7 +338,7 @@ class TestTC(TypeCheckingBaseTest):
                     self.v4: self.IxN_nonscalar,
                     self.v5: self.IxN_nonscalar})
 
-        # This shouldn't typecheck...
+        # This shouldn't typecheck. We should add unification and reject it.
         self.runTC(r,
                    {self.v0: self.IxN_nonscalar,
                     self.v1: self.IxN_nonscalar,
@@ -332,7 +350,7 @@ class TestTC(TypeCheckingBaseTest):
                     self.v4: TxN,
                     self.v5: TxN})
 
-        # And neither should this
+        # And neither should this. Again add unification and reject it.
         self.runTC(r,
                    {self.v0: self.IxN_nonscalar,
                     self.v1: self.IxN2_nonscalar,

--- a/lib/cretonne/meta/cdsl/test_tc.py
+++ b/lib/cretonne/meta/cdsl/test_tc.py
@@ -347,6 +347,9 @@ class TestTC(TypeCheckingBaseTest):
                     self.v3: self.IxN2_nonscalar},
                    TCNotSubtype((r, 1, True, 2), None, None))
 
+        # TODO: Add a test for initial env {v0: IxN_nonscalar,..,v3: TxN} when
+        # we get constraints
+
     def test_bad_double_split(self):
         r = Rtl(
                 self.v0 << vselect(self.v1, self.v2, self.v3),

--- a/lib/cretonne/meta/cdsl/test_tc.py
+++ b/lib/cretonne/meta/cdsl/test_tc.py
@@ -1,0 +1,241 @@
+from __future__ import absolute_import
+from base.instructions import vselect, vsplit, vconcat, TxN, iconst
+from .typevar import TypeVar
+from .tc import tc_rtl, TCError, resolve, TCNotSubtype, io_shape,\
+        to_TypeMap
+from .ast import Var
+from .xform import Rtl
+from unittest import TestCase
+
+
+class TypeCheckingBaseTest(TestCase):
+    def setUp(self):
+        self.vm1 = Var("vm1")
+        self.v0 = Var("v0")
+        self.v1 = Var("v1")
+        self.v2 = Var("v2")
+        self.v3 = Var("v3")
+        self.v4 = Var("v4")
+        self.v5 = Var("v5")
+        self.v6 = Var("v6")
+        self.v7 = Var("v7")
+        self.v8 = Var("v8")
+        self.v9 = Var("v9")
+        self.imm0 = Var("imm0")
+
+        self.simd4_256 = TypeVar("simd4_256", "", ints=True, floats=True,
+                                 bools=True, simd=(4, 256))
+
+        self.simd8_64 = TypeVar("simd8_64", "", ints=True, floats=True,
+                                bools=True, simd=(8, 64))
+
+        self.b4_256 = TypeVar("b4_256", "", ints=False, floats=False,
+                              bools=(1, 1), simd=(4, 256))
+
+
+class TestIOShape(TypeCheckingBaseTest):
+    def test_vselect(self):
+        r = Rtl(
+                self.v0 << vselect(self.v1, self.v2, self.v3)
+        )
+
+        self.assertEqual(io_shape(r),
+                         (set([self.v1, self.v2, self.v3]),  # Inputs
+                          set([self.v2]),  # Control Vars
+                          set([self.v0])))  # Defs
+
+    def test_double_split(self):
+        r = Rtl(
+                self.v0 << vselect(self.v1, self.v2, self.v3),
+                (self.v4, self.v5) << vsplit(self.v0),
+                (self.v6, self.v7) << vsplit(self.v4),
+        )
+
+        self.assertEqual(io_shape(r),
+                         (set([self.v1, self.v2, self.v3]),  # Inputs
+                          set([self.v2]),  # Control Vars
+                          set([self.v0, self.v4, self.v5, self.v6,
+                               self.v7])))  # Defs
+
+    def test_pattern3(self):
+        r = Rtl(
+                self.v0 << vselect(self.v1, self.v2, self.v3),
+                self.v4 << vconcat(self.v0, self.v0),
+                self.v5 << vconcat(self.v4, self.vm1),
+                (self.v6, self.v7) << vsplit(self.v0),
+                (self.v8, self.v9) << vsplit(self.v6),
+        )
+
+        self.assertEqual(io_shape(r),
+                         (set([self.v1, self.v2, self.v3, self.vm1]),  # Inputs
+                          set([self.v2]),  # Control Vars
+                          set([self.v0, self.v4, self.v5, self.v6,
+                               self.v7, self.v8, self.v9])))  # Defs
+
+    def test_iconst(self):
+        # for iconst the type-controlling variable
+        # is the definition (v0 in this case)
+        r = Rtl(
+                self.v0 << iconst(self.imm0),
+        )
+
+        self.assertEqual(io_shape(r),
+                         (set([self.imm0]),  # Inputs
+                          set([self.v0]),  # Control Vars
+                          set([self.v0])))  # Defs
+
+    def test_pattern4(self):
+        # A more complex pattern involving iconst
+        # The v2 control variable comes from inputs,
+        # while the v1 control variable comes from defs
+        r = Rtl(
+                self.v1 << iconst(self.imm0),
+                self.v0 << vselect(self.v1, self.v2, self.v3),
+                self.v4 << vconcat(self.v0, self.v0),
+                self.v5 << vconcat(self.v4, self.vm1),
+                (self.v6, self.v7) << vsplit(self.v0),
+                (self.v8, self.v9) << vsplit(self.v6),
+        )
+
+        self.assertEqual(io_shape(r),
+                         (set([self.imm0, self.v2, self.v3,
+                               self.vm1]),  # Inputs
+                          set([self.v2, self.v1]),  # Control Vars
+                          set([self.v1, self.v0, self.v4, self.v5, self.v6,
+                               self.v7, self.v8, self.v9])))  # Defs
+
+    def test_pattern4_swap(self):
+        # Same code as test_pattern4, but self.vm1 and self.v4 are
+        # swapped on line 4. This adds self.vm1 to the set of
+        # control-relevant variables. This is due to the fact
+        # that our algorithm is rather naive and doesn't do unification.
+        r = Rtl(
+                self.v1 << iconst(self.imm0),
+                self.v0 << vselect(self.v1, self.v2, self.v3),
+                self.v4 << vconcat(self.v0, self.v0),
+                self.v5 << vconcat(self.vm1, self.v4),
+                (self.v6, self.v7) << vsplit(self.v0),
+                (self.v8, self.v9) << vsplit(self.v6),
+        )
+
+        self.assertEqual(io_shape(r),
+                         (set([self.imm0, self.v2, self.v3,
+                               self.vm1]),  # Inputs
+                          set([self.v2, self.v1, self.vm1]),  # Control Vars
+                          set([self.v1, self.v0, self.v4, self.v5, self.v6,
+                               self.v7, self.v8, self.v9])))  # Defs
+
+
+class TestTypeChecking(TypeCheckingBaseTest):
+    def ppFail(self, r, m, msg):
+        msg += "\n Partially inferred types: \n"
+        for (k, v) in m.items():
+            msg += "{} := {}\n".format(k, v)
+        self.fail(msg)
+
+    def runTC(self, rtl, initialEnv, res):
+        try:
+            m = tc_rtl(rtl, to_TypeMap(initialEnv))
+        except TCError as e:
+            if e == res:
+                return True
+            else:
+                if isinstance(res, TCError):
+                    self.ppFail(rtl, {},
+                                "Expected exception {} instead got exc {}"
+                                .format(repr(res), repr(e)))
+                else:
+                    self.ppFail(rtl, {}, "Got unexpected exception {}"
+                                .format(repr(e)))
+                return False
+
+        if (isinstance(res, TCError)):
+            self.ppFail(rtl, m, "Expected exception {} - instead no error."
+                        .format(res))
+            return False
+        elif (isinstance(res, dict)):
+            res = {k.get_typevar(): v for (k, v) in res.items()}
+            for (k, v) in res.items():
+                if k not in m:
+                    self.ppFail(rtl, m,
+                                ": Did not infer type for {}".format(k))
+                    return False
+
+                if not (m[k] == res[k]):
+                    self.ppFail(rtl, m,
+                                   "Inferred wrong type for {}. Got {} expected {}" # noqa
+                                   .format(k, m[k], res[k]))
+                    return False
+            return True
+        else:
+            for (k, tv) in m.items():
+                print(k, "==", resolve(tv, m))
+            return True
+
+    def test_vselect(self):
+        # Make sure we infer the type of v0 to be same as v2
+        r = Rtl(
+                self.v0 << vselect(self.v1, self.v2, self.v3)
+        )
+
+        self.runTC(r,
+                   {self.v2: self.simd8_64,
+                    self.v3: self.simd8_64,
+                    self.v1: self.simd8_64.as_bool()},
+                   {self.v0: self.simd8_64})
+
+        self.runTC(r,
+                   {self.v2: TxN, self.v3: TxN, self.v1: TxN.as_bool()},
+                   {self.v0: TxN, self.v2: TxN, self.v3: TxN,
+                    self.v1: TxN.as_bool()})
+
+    def test_bad_vselect(self):
+        r = Rtl(
+                self.v0 << vselect(self.v1, self.v2, self.v3)
+        )
+
+        # Make sure we flag an error if v1 was specified
+        # to be anything but as_bool(T) where v2: T
+        self.runTC(r,
+                   {self.v2: TxN, self.v3: TxN, self.v1: TxN},
+                   TCNotSubtype((r, 0, True, 0), None, None))
+
+        self.runTC(r,
+                   {self.v2: TxN, self.v3: TxN, self.v1: self.b4_256},
+                   TCNotSubtype((r, 0, True, 0), None, None))
+
+    def test_bad_double_split(self):
+        r1 = Rtl(
+                self.v0 << vselect(self.v1, self.v2, self.v3),
+                (self.v4, self.v5) << vsplit(self.v0),
+                (self.v6, self.v7) << vsplit(self.v4),
+        )
+
+        # v0 here has the same type as v2 - TxN which is 2..256 simd.
+        # Therefore v4 has the type half_vector(TxN) which is 1..128 simd.
+        # However the last vsplit requires v4 to be TxN (at least 2 lanes)
+        # This causes a subtyping error
+
+        self.runTC(r1,
+                   {self.v2: TxN, self.v3: TxN,
+                    self.v1: TxN.as_bool()},
+                   TCNotSubtype((r1, 2, True, 0), None, None))
+
+    def test_double_split(self):
+        r1 = Rtl(
+                self.v0 << vselect(self.v1, self.v2, self.v3),
+                (self.v4, self.v5) << vsplit(self.v0),
+                (self.v6, self.v7) << vsplit(self.v4),
+        )
+
+        # v0 here has the same type as v2 - TxN which is 2..256 simd.
+        # Therefore v4 has the type half_vector(TxN) which is 1..128 simd.
+        # However the last vsplit requires v4 to be TxN (at least 2 lanes)
+        # This causes a subtyping error
+
+        self.runTC(r1,
+                   {self.v2: self.simd4_256,
+                    self.v3: self.simd4_256,
+                    self.v1: self.simd4_256.as_bool()},
+                   {self.v0: self.simd4_256,
+                    self.v4: self.simd4_256.half_vector()})

--- a/lib/cretonne/meta/cdsl/test_tc.py
+++ b/lib/cretonne/meta/cdsl/test_tc.py
@@ -141,7 +141,7 @@ class TestIOShape(TypeCheckingBaseTest):
         )
 
         self.assertEqual(io_shape(r),
-                         (set([self.imm0]),  # Inputs
+                         (set([]),  # Inputs
                           set([self.v0]),  # Control Vars
                           set([]),  # Free Non-Derived TVs
                           set([self.v0])))  # Defs
@@ -160,7 +160,7 @@ class TestIOShape(TypeCheckingBaseTest):
         )
 
         self.assertEqual(io_shape(r),
-                         (set([self.imm0, self.v2, self.v3,
+                         (set([self.v2, self.v3,
                                self.vm1]),  # Inputs
                           set([self.v2, self.v1]),  # Control Vars
                           set([]),  # Free Non-Derived TVs
@@ -182,7 +182,7 @@ class TestIOShape(TypeCheckingBaseTest):
         )
 
         self.assertEqual(io_shape(r),
-                         (set([self.imm0, self.v2, self.v3,
+                         (set([self.v2, self.v3,
                                self.vm1]),  # Inputs
                           set([self.v2, self.v1, self.vm1]),  # Control Vars
                           set([]),  # Free Non-Derived TVs
@@ -291,12 +291,7 @@ class TestTC(TypeCheckingBaseTest):
         self.runTC(r,
                    {self.v0: self.IxN_nonscalar,
                     self.v3: TxN},
-                   {self.v0: self.IxN_nonscalar,
-                    self.v1: self.IxN_nonscalar,
-                    self.v2: self.IxN_nonscalar.as_bool(),
-                    self.v3: TxN,
-                    self.v4: TxN,
-                    self.v5: TxN})
+                   TCNotSubtype((r, 2, True, 0), None, None))
 
     def test_vselect_imm(self):
         r = Rtl(
@@ -343,24 +338,14 @@ class TestTC(TypeCheckingBaseTest):
                    {self.v0: self.IxN_nonscalar,
                     self.v1: self.IxN_nonscalar,
                     self.v3: TxN},
-                   {self.v0: self.IxN_nonscalar,
-                    self.v1: self.IxN_nonscalar,
-                    self.v2: self.IxN_nonscalar.as_bool(),
-                    self.v3: TxN,
-                    self.v4: TxN,
-                    self.v5: TxN})
+                   TCNotSubtype((r, 2, True, 0), None, None))
 
         # And neither should this. Again add unification and reject it.
         self.runTC(r,
                    {self.v0: self.IxN_nonscalar,
                     self.v1: self.IxN2_nonscalar,
-                    self.v3: TxN},
-                   {self.v0: self.IxN_nonscalar,
-                    self.v1: self.IxN2_nonscalar,
-                    self.v2: self.IxN2_nonscalar.as_bool(),
-                    self.v3: TxN,
-                    self.v4: TxN,
-                    self.v5: TxN})
+                    self.v3: self.IxN2_nonscalar},
+                   TCNotSubtype((r, 1, True, 2), None, None))
 
     def test_bad_double_split(self):
         r = Rtl(

--- a/lib/cretonne/meta/cdsl/test_typevar.py
+++ b/lib/cretonne/meta/cdsl/test_typevar.py
@@ -45,6 +45,61 @@ class TestTypeSet(TestCase):
         with self.assertRaises(AssertionError):
             a in s
 
+    def test_derived_constructors(self):
+        a = TypeSet(lanes=(2, 4), ints=(16, 32), floats=None, bools=(16, 32))
+        a_hlf = TypeSet(lanes=(2, 4), ints=(8, 16), floats=None, bools=(8, 16))
+        a_dbl = TypeSet(lanes=(2, 4), ints=(32, 64), floats=None,
+                        bools=(32, 64))
+        a_dbl_v = TypeSet(lanes=(4, 8), ints=(16, 32), floats=None,
+                          bools=(16, 32))
+        a_hlf_v = TypeSet(lanes=(1, 2), ints=(16, 32), floats=None,
+                          bools=(16, 32))
+        a_bool = TypeSet(lanes=(2, 4), ints=False, floats=False, bools=(1, 1))
+        a_lane = TypeSet(lanes=(1, 1), ints=(16, 32), floats=None,
+                         bools=(16, 32))
+
+        f64 = TypeSet(lanes=(2, 4), ints=None, floats=(64, 64), bools=None)
+        f32 = TypeSet(lanes=(2, 4), ints=None, floats=(32, 32), bools=None)
+        f64_hv = TypeSet(lanes=(1, 2), ints=None, floats=(64, 64), bools=None)
+        f32_dv = TypeSet(lanes=(4, 8), ints=None, floats=(32, 32), bools=None)
+        large_simd = TypeSet(lanes=(1, 256), ints=True, floats=True)
+        f32_bool = TypeSet(lanes=(2, 4), ints=None, floats=None, bools=(1, 1))
+
+        # Check half/double width/vector works correctly
+        self.assertEqual(a.half_width(), a_hlf)
+        self.assertEqual(a.double_width(), a_dbl)
+        self.assertEqual(a.half_vector(), a_hlf_v)
+        self.assertEqual(a.double_vector(), a_dbl_v)
+
+        self.assertEqual(f64.half_width(), f32)
+        self.assertEqual(f32.double_width(), f64)
+        self.assertEqual(f64.half_vector(), f64_hv)
+        self.assertEqual(f32.double_vector(), f32_dv)
+
+        # Check half/double width/vector fails when going outside the full
+        # range
+        with self.assertRaises(AssertionError):
+            a_dbl.double_width()
+        with self.assertRaises(AssertionError):
+            a_hlf.half_width()
+        with self.assertRaises(AssertionError):
+            f64.double_width()
+        with self.assertRaises(AssertionError):
+            f32.half_width()
+        with self.assertRaises(AssertionError):
+            a_hlf_v.half_vector()
+        with self.assertRaises(AssertionError):
+            f64_hv.half_vector()
+        with self.assertRaises(AssertionError):
+            large_simd.double_vector()
+
+        # Check as_bool works. No edge cases here I think?
+        self.assertEqual(a_dbl.as_bool(), a_bool)
+        self.assertEqual(f32.as_bool(), f32_bool)
+
+        # Check lane_of. TODO: What happens when called on scalar?
+        self.assertEqual(a.lane_of(), a_lane)
+
 
 class TestTypeVar(TestCase):
     def test_functions(self):

--- a/lib/cretonne/meta/cdsl/typevar.py
+++ b/lib/cretonne/meta/cdsl/typevar.py
@@ -7,6 +7,7 @@ polymorphic by using type variables.
 from __future__ import absolute_import
 import math
 from . import types, is_power_of_two
+from copy import copy
 
 try:
     from typing import Tuple, Union, Callable, TYPE_CHECKING # noqa
@@ -454,6 +455,24 @@ class TypeVar(object):
                 ints, floats, bools, simd=lanes)
         tv.singleton_type = typ
         return tv
+
+    def intersection(self, other):
+        # type: (TypeVar, TypeVar) -> TypeVar
+        """
+        Return the intersection of self and the other type var. Only legal to
+        call this with non-derived type variables.
+        """
+        assert not self.is_derived and not other.is_derived
+        ts = copy(self.type_set)
+        ts &= other.type_set
+
+        return TypeVar("Intersection({}, {})".format(self.name, other.name),
+                       "",
+                       ints=ts.ints(),
+                       floats=ts.floats(),
+                       bools=ts.bools(),
+                       simd=ts.lanes(),
+                       scalars=True)
 
     def __str__(self):
         # type: () -> str

--- a/lib/cretonne/meta/cdsl/typevar.py
+++ b/lib/cretonne/meta/cdsl/typevar.py
@@ -9,7 +9,7 @@ import math
 from . import types, is_power_of_two
 
 try:
-    from typing import Tuple, Union, TYPE_CHECKING # noqa
+    from typing import Tuple, Union, Callable, TYPE_CHECKING # noqa
     if TYPE_CHECKING:
         from srcgen import Formatter  # noqa
         Interval = Tuple[int, int]
@@ -20,6 +20,11 @@ except ImportError:
 
 MAX_LANES = 256
 MAX_BITS = 64
+
+INT_RANGE = (1, MAX_BITS)
+FLOAT_RANGE = (32, 64)
+BOOL_RANGE = (1, MAX_BITS)
+LANES_RANGE = (1, MAX_LANES)
 
 
 def int_log2(x):
@@ -46,6 +51,63 @@ def intersect(a, b):
         return (None, None)
 
 
+def valid_interval(interval, full_range):
+    # type: (Interval, Interval) -> bool
+    """
+    Given a an interval, and a full_range=(min,max) for it return true if
+    the interval is valid. That is it is one of the following:
+        - None
+        - (None, None)
+        - (lo, hi) where
+            lo <= hi
+            lo >= min and hi <= max
+            is_pow2(lo) and is_pow2(hi)
+    """
+    (min, max) = full_range
+    if (interval is None):
+        return True
+
+    (lo, hi) = interval
+
+    if (lo is None and hi is None):
+        return True
+
+    if (lo is None or hi is None):
+        return False
+
+    if (not is_power_of_two(lo) or
+       not is_power_of_two(hi) or
+       lo > hi or
+       lo < min or
+       hi > max):
+        return False
+
+    return True
+
+
+def map_interval(interval, f, full_range):
+    # type: (Interval, Callable[[int], int], Interval) -> Interval
+    """
+    If interval is non-empty (not None/(None,None) map f over its endpoints
+    and return the new range. Assert that the original and resulting ranges
+    are valid.
+    """
+    assert valid_interval(interval, full_range)
+
+    if (interval is None or interval == (None, None)):
+        return None
+    else:
+        (lo, hi) = interval
+        new_interval = (f(lo), f(hi))
+        assert valid_interval(new_interval, full_range)
+        return new_interval
+
+
+def encode_interval(lo, hi, full_range):
+    # type: (int, int, Interval) -> Interval
+    return map_interval((lo, hi), lambda x:  x, full_range)
+
+
 def decode_interval(intv, full_range, default=None):
     # type: (BoolInterval, Interval, int) -> Interval
     """
@@ -61,11 +123,7 @@ def decode_interval(intv, full_range, default=None):
     if isinstance(intv, tuple):
         # mypy buig here: 'builtins.None' object is not iterable
         lo, hi = intv
-        assert is_power_of_two(lo)
-        assert is_power_of_two(hi)
-        assert lo <= hi
-        assert lo >= full_range[0]
-        assert hi <= full_range[1]
+        assert valid_interval((lo, hi), full_range)
         return intv
 
     if intv:
@@ -152,7 +210,7 @@ class TypeSet(object):
             return False
 
     def __repr__(self):
-        # type: () -> str
+        # type: (TypeSet) -> str
         s = 'TypeSet(lanes=({}, {})'.format(self.min_lanes, self.max_lanes)
         if self.min_int is not None:
             s += ', ints=({}, {})'.format(self.min_int, self.max_int)
@@ -214,6 +272,109 @@ class TypeSet(object):
                 (other.min_bool, other.max_bool))
 
         return self
+
+    def is_subset(self, other):
+        # type: (TypeSet) -> bool
+        """
+        Return true if self is a subset of other and false otherwise.
+        """
+        if (self.min_lanes < other.min_lanes or
+           self.max_lanes > other.max_lanes):
+            return False
+
+        if (self.min_int < other.min_int or
+           self.max_int > other.max_int):
+            return False
+
+        if (self.min_float < other.min_float or
+           self.max_float > other.max_float):
+            return False
+
+        if (self.min_bool < other.min_bool or
+           self.max_bool > other.max_bool):
+            return False
+
+        return True
+
+    def lanes(self):
+        # type: (TypeSet) -> Interval
+        return encode_interval(self.min_lanes, self.max_lanes, LANES_RANGE)
+
+    def ints(self):
+        # type: (TypeSet) -> Interval
+        return encode_interval(self.min_int, self.max_int, INT_RANGE)
+
+    def floats(self):
+        # type: (TypeSet) -> Interval
+        return encode_interval(self.min_float, self.max_float, FLOAT_RANGE)
+
+    def bools(self):
+        # type: (TypeSet) -> Interval
+        return encode_interval(self.min_bool, self.max_bool, BOOL_RANGE)
+
+    def lane_of(self):
+        # type: (TypeSet) -> TypeSet
+        return TypeSet(
+            lanes=(1, 1),
+            ints=self.ints(),
+            floats=self.floats(),
+            bools=self.bools())
+
+    def as_bool(self):
+        # type: (TypeSet) -> TypeSet
+        return TypeSet(
+            lanes=self.lanes(),
+            ints=None,
+            floats=None,
+            bools=(1, 1))
+
+    def half_width(self):
+        # type: (TypeSet) -> TypeSet
+        def half(x):
+            # type: (int) -> int
+            return x // 2
+
+        return TypeSet(
+            lanes=self.lanes(),
+            ints=map_interval(self.ints(), half, INT_RANGE),
+            floats=map_interval(self.floats(), half, FLOAT_RANGE),
+            bools=map_interval(self.bools(), half, BOOL_RANGE))
+
+    def double_width(self):
+        # type: (TypeSet) -> TypeSet
+        def double(x):
+            # type: (int) -> int
+            return x * 2
+
+        return TypeSet(
+                lanes=self.lanes(),
+                ints=map_interval(self.ints(), double, INT_RANGE),
+                floats=map_interval(self.floats(), double, FLOAT_RANGE),
+                bools=map_interval(self.bools(), double, BOOL_RANGE))
+
+    def half_vector(self):
+        # type: (TypeSet) -> TypeSet
+        def half(x):
+            # type: (int) -> int
+            return x // 2
+
+        return TypeSet(
+            lanes=map_interval(self.lanes(), half, LANES_RANGE),
+            ints=self.ints(),
+            floats=self.floats(),
+            bools=self.bools())
+
+    def double_vector(self):
+        # type: (TypeSet) -> TypeSet
+        def double(x):
+            # type: (int) -> int
+            return x * 2
+
+        return TypeSet(
+            lanes=map_interval(self.lanes(), double, LANES_RANGE),
+            ints=self.ints(),
+            floats=self.floats(),
+            bools=self.bools())
 
 
 class TypeVar(object):
@@ -486,3 +647,30 @@ class TypeVar(object):
         #
         # For the fully general case, we would need to compute an image typeset
         # for `b` and propagate a `a.derived_func` pre-image to `a.base`.
+
+    def get_typeset(self):
+        # type: (TypeVar) -> TypeSet
+        """
+        Returns the typeset for this TV. If the TV is derived, computes it
+        recursively from the derived function and the base's typeset.
+        """
+        if hasattr(self, "type_set"):
+            return self.type_set
+        else:
+            assert self.is_derived
+            if (self.derived_func == TypeVar.SAMEAS):
+                return self.base.get_typeset()
+            elif (self.derived_func == TypeVar.LANEOF):
+                return self.base.get_typeset().lane_of()
+            elif (self.derived_func == TypeVar.ASBOOL):
+                return self.base.get_typeset().as_bool()
+            elif (self.derived_func == TypeVar.HALFWIDTH):
+                return self.base.get_typeset().half_width()
+            elif (self.derived_func == TypeVar.DOUBLEWIDTH):
+                return self.base.get_typeset().double_width()
+            elif (self.derived_func == TypeVar.HALFVECTOR):
+                return self.base.get_typeset().half_vector()
+            elif (self.derived_func == TypeVar.DOUBLEVECTOR):
+                return self.base.get_typeset().double_vector()
+            else:
+                assert False, "Unknown derived function: " + self.derived_func

--- a/lib/cretonne/meta/cdsl/typevar.py
+++ b/lib/cretonne/meta/cdsl/typevar.py
@@ -506,6 +506,13 @@ class TypeVar(object):
         """Create a type variable that is a function of another."""
         return TypeVar(None, None, base=base, derived_func=derived_func)
 
+    def get_nonderived_base(self):
+        # type: (TypeVar) -> TypeVar
+        base = self
+        while base.is_derived:
+            base = base.base
+        return base
+
     def change_to_derived(self, base, derived_func):
         # type: (TypeVar, str) -> None
         """Change this type variable into a derived one."""

--- a/lib/cretonne/meta/cdsl/xform.py
+++ b/lib/cretonne/meta/cdsl/xform.py
@@ -83,6 +83,7 @@ class XForm(object):
         self._rewrite_rtl(src, symtab, Var.SRCCTX)
         num_src_inputs = len(self.inputs)
         self._rewrite_rtl(dst, symtab, Var.DSTCTX)
+        self.symtab = symtab
 
         # Check for inconsistently used inputs.
         for i in self.inputs:


### PR DESCRIPTION
This is a first hash of type-checking for Rtl/XForms in the meta-language - just to get the ball rolling. Most of the code is in:

lib/cretonne/meta/cdsl/tc.py

with example usage in:

lib/cretonne/meta/cdsl/test_tc.py

Specifically tc.py defines these entry points:

tc_rtl(r, m) -> m'  where r : Rtl, m, m': Dict[Var, TypeVar]
tc_xform(x, m) -> m' where x: XForm, m, m': Dict[Var, TypeVar]

The design is that we do as minimum inference as possible - we require the consumer to specify in the initial map m all control variables necessary to monomorphise instructions. The consumer can also optionally specify the types of any free input variables that are not derived from control variables; if not specified, their types will be inferred based on the uses of those vars. The types of all variables defined in the Rtl/XForm will be inferred based on the monomorphic type of their defining instruction.

We don't do unification, but when we check if the actual type of a variable agrees with the monomorphic type of its use location we do check for 'structural' equality of the two types. That is, if they are both derived type vars, we check that the deriving function is the same, and recursively check the equality of the base TVs. This is necessary for cases such as the following instruction sequence:

v0 << iconst(imm0)
v2 << icmp(ne, v1, v0)
v5 << vselect(v2, v3, v4)

Here v0, v1 and v3 are control variables and must be provided by the consumer. The type checker needs to confirm that v0, v1 and v3 have the same number of lanes. For v0 and v1 this is achieved because:

1) Since v1 is the control var for icmp, we monomorphise the polymorphic icmp: (Cond, IxN, IxN) -> as_bool(IxN) to the concrete type (Cond, Tv0, Tv0) -> as_bool(Tv0)
2) Since v0 is passed at the third argument, we check that Tv1 agrees with Tv0. The only way to satisfy this structurally is by Tv1 == Tv0 (since they are both non-derived)

For v3 this holds because:

1) Since v3 is the control var for vselect we monomorphise the type of vselect to (as_bool(Tv3), Tv3, Tv3) -> Tv3

2) Since v2 is passed as the first argument, we check that Tv2 agrees with as_bool(Tv3). However Tv2 in our environment is defined to be as_bool(Tv0). So we check that as_bool(Tv0) agrees with as_bool(Tv3), which works iff Tv0 == Tv3.

This way, the TC will type check this pattern iff v0,v1, v3 are mapped to the same vector integer type.