### PR TITLE
Documentation fixes

### DIFF
--- a/docs/compare-llvm.rst
+++ b/docs/compare-llvm.rst
@@ -152,7 +152,7 @@ can hold.
   address type too.
 - SIMD vector types are limited to a power-of-two number of vector lanes up to
   256. LLVM allows an arbitrary number of SIMD lanes.
-- Cretonne has no aggregrate types. LLVM has named and anonymous struct types as
+- Cretonne has no aggregate types. LLVM has named and anonymous struct types as
   well as array types.
 
 Cretonne has multiple boolean types, whereas LLVM simply uses `i1`. The sized
@@ -160,7 +160,7 @@ Cretonne boolean types are used to represent SIMD vector masks like ``b32x4``
 where each lane is either all 0 or all 1 bits.
 
 Cretonne instructions and function calls can return multiple result values. LLVM
-instead models this by returning a single value of an aggregrate type.
+instead models this by returning a single value of an aggregate type.
 
 Instruction set
 ---------------

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -253,7 +253,7 @@ indicate the different kinds of immediate operands on an instruction.
     A signed 32-bit immediate address offset.
 
     In the textual format, :type:`offset32` immediates always have an explicit
-    sign, and a 0 offset may beomitted.
+    sign, and a 0 offset may be omitted.
 
 .. type:: ieee32
 

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -40,9 +40,9 @@ that can be referenced inside the function. In the example above, the preamble
 declares a single local variable, ``ss1``.
 
 After the preamble follows the :term:`function body` which consists of
-:term:`extended basic block`\s, the first of which is the :term:`entry block`.
-Every EBB ends with a :term:`terminator instruction`, so execution can never
-fall through to the next EBB without an explicit branch.
+:term:`extended basic block`\s (EBBs), the first of which is the
+:term:`entry block`. Every EBB ends with a :term:`terminator instruction`, so
+execution can never fall through to the next EBB without an explicit branch.
 
 A ``.cton`` file consists of a sequence of independent function definitions:
 

--- a/docs/regalloc.rst
+++ b/docs/regalloc.rst
@@ -55,12 +55,12 @@ EBB argument fixup
 
 The contract between the spilling and coloring phases is that the number of
 values in registers never exceeds the number of available registers. This
-sounds simple enough in theory, but in pratice there are some complications.
+sounds simple enough in theory, but in practice there are some complications.
 
 Real-world complications to SSA coloring
 ----------------------------------------
 
-In practice, instruction set architectures don't have "K interchangable
+In practice, instruction set architectures don't have "K interchangeable
 registers", and register pressure can't be measured with a single number. There
 are complications:
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -100,7 +100,7 @@ of input functions in the :doc:`Cretonne textual intermediate language
 
 The available test commands are described below.
 
-Many test comands only make sense in the context of a target instruction set
+Many test commands only make sense in the context of a target instruction set
 architecture. These tests require one or more ISA specifications in the test
 header:
 

--- a/lib/cretonne/meta/base/instructions.py
+++ b/lib/cretonne/meta/base/instructions.py
@@ -713,7 +713,8 @@ imul_imm = Instruction(
         'imul_imm', """
         Integer multiplication by immediate constant.
 
-        Polymorphic over all scalar integer types.
+        Polymorphic over all scalar integer types, but does not support vector
+        types.
         """,
         ins=(x, Y), outs=a)
 

--- a/lib/cretonne/meta/base/instructions.py
+++ b/lib/cretonne/meta/base/instructions.py
@@ -913,18 +913,33 @@ a = Operand('a', iB)
 band_imm = Instruction(
         'band_imm', """
         Bitwise and with immediate.
+
+        Same as :inst:`band`, but one operand is an immediate constant.
+
+        Polymorphic over all scalar integer types, but does not support vector
+        types.
         """,
         ins=(x, Y), outs=a)
 
 bor_imm = Instruction(
         'bor_imm', """
         Bitwise or with immediate.
+
+        Same as :inst:`bor`, but one operand is an immediate constant.
+
+        Polymorphic over all scalar integer types, but does not support vector
+        types.
         """,
         ins=(x, Y), outs=a)
 
 bxor_imm = Instruction(
         'bxor_imm', """
         Bitwise xor with immediate.
+
+        Same as :inst:`bxor`, but one operand is an immediate constant.
+
+        Polymorphic over all scalar integer types, but does not support vector
+        types.
         """,
         ins=(x, Y), outs=a)
 

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -625,7 +625,7 @@ impl<'a> Parser<'a> {
                     // Apply the ISA-specific settings to `isa_builder`.
                     isaspec::parse_options(words, &mut isa_builder, &self.loc)?;
 
-                    // Construct a trait object with the aggregrate settings.
+                    // Construct a trait object with the aggregate settings.
                     isas.push(isa_builder.finish(settings::Flags::new(&flag_builder)));
                 }
                 _ => break,


### PR DESCRIPTION
While reading the docs, I noticed that the documentation for `_imm` instructions isn't entirely consistent. This PR fixes a few examples of this. Are you interested in fixing all the `_imm` instructions this way, or would you prefer to factor this text out somehow?