### PR TITLE
Add image computation of typesets; Remove TypeVar.singleton_type

### DIFF
--- a/lib/cretonne/meta/base/types.py
+++ b/lib/cretonne/meta/base/types.py
@@ -2,15 +2,10 @@
 The base.types module predefines all the Cretonne scalar types.
 """
 from __future__ import absolute_import
-from cdsl.types import ScalarType, IntType, FloatType, BoolType
+from cdsl.types import IntType, FloatType, BoolType
 
 #: Boolean.
-b1 = ScalarType(
-        'b1', 0,
-        """
-        A boolean value that is either true or false.
-        """)
-
+b1 = BoolType(1)    #: 1-bit bool. Type is abstract (can't be stored in mem)
 b8 = BoolType(8)    #: 8-bit bool.
 b16 = BoolType(16)  #: 16-bit bool.
 b32 = BoolType(32)  #: 32-bit bool.

--- a/lib/cretonne/meta/cdsl/instructions.py
+++ b/lib/cretonne/meta/cdsl/instructions.py
@@ -186,7 +186,7 @@ class Instruction(object):
             try:
                 opnum = self.value_opnums[self.format.typevar_operand]
                 tv = self.ins[opnum].typevar
-                if tv is tv.free_typevar():
+                if tv is tv.free_typevar() or tv.singleton_type() is not None:
                     self.other_typevars = self._verify_ctrl_typevar(tv)
                     self.ctrl_typevar = tv
                     self.use_typevar_operand = True

--- a/lib/cretonne/meta/cdsl/types.py
+++ b/lib/cretonne/meta/cdsl/types.py
@@ -97,7 +97,7 @@ class VectorType(ValueType):
         # type: (ScalarType, int) -> None
         assert isinstance(base, ScalarType), 'SIMD lanes must be scalar types'
         super(VectorType, self).__init__(
-                name='{}x{}'.format(base.name, lanes),
+                name=VectorType.get_name(base, lanes),
                 membytes=lanes*base.membytes,
                 doc="""
                 A SIMD vector with {} lanes containing a `{}` each.
@@ -111,6 +111,11 @@ class VectorType(ValueType):
         return ('VectorType(base={}, lanes={})'
                 .format(self.base.name, self.lanes))
 
+    @staticmethod
+    def get_name(base, lanes):
+        # type: (ValueType, int) -> str
+        return '{}x{}'.format(base.name, lanes)
+
 
 class IntType(ScalarType):
     """A concrete scalar integer type."""
@@ -119,7 +124,7 @@ class IntType(ScalarType):
         # type: (int) -> None
         assert bits > 0, 'IntType must have positive number of bits'
         super(IntType, self).__init__(
-                name='i{:d}'.format(bits),
+                name=IntType.get_name(bits),
                 membytes=bits // 8,
                 doc="An integer type with {} bits.".format(bits))
         self.bits = bits
@@ -127,6 +132,11 @@ class IntType(ScalarType):
     def __repr__(self):
         # type: () -> str
         return 'IntType(bits={})'.format(self.bits)
+
+    @staticmethod
+    def get_name(bits):
+        # type: (int) -> str
+        return 'i{:d}'.format(bits)
 
 
 class FloatType(ScalarType):
@@ -136,7 +146,7 @@ class FloatType(ScalarType):
         # type: (int, str) -> None
         assert bits > 0, 'FloatType must have positive number of bits'
         super(FloatType, self).__init__(
-                name='f{:d}'.format(bits),
+                name=FloatType.get_name(bits),
                 membytes=bits // 8,
                 doc=doc)
         self.bits = bits
@@ -144,6 +154,11 @@ class FloatType(ScalarType):
     def __repr__(self):
         # type: () -> str
         return 'FloatType(bits={})'.format(self.bits)
+
+    @staticmethod
+    def get_name(bits):
+        # type: (int) -> str
+        return 'f{:d}'.format(bits)
 
 
 class BoolType(ScalarType):
@@ -153,7 +168,7 @@ class BoolType(ScalarType):
         # type: (int) -> None
         assert bits > 0, 'BoolType must have positive number of bits'
         super(BoolType, self).__init__(
-                name='b{:d}'.format(bits),
+                name=BoolType.get_name(bits),
                 membytes=bits // 8,
                 doc="A boolean type with {} bits.".format(bits))
         self.bits = bits
@@ -161,3 +176,8 @@ class BoolType(ScalarType):
     def __repr__(self):
         # type: () -> str
         return 'BoolType(bits={})'.format(self.bits)
+
+    @staticmethod
+    def get_name(bits):
+        # type: (int) -> str
+        return 'b{:d}'.format(bits)

--- a/lib/cretonne/meta/cdsl/xform.py
+++ b/lib/cretonne/meta/cdsl/xform.py
@@ -254,7 +254,7 @@ class XForm(object):
         # Some variables have a fixed type which appears as a type variable
         # with a singleton_type field set. That's allowed for temps too.
         for v in fvars:
-            if v.is_temp() and not v.typevar.singleton_type:
+            if v.is_temp() and not v.typevar.singleton_type():
                 raise AssertionError(
                         "Cannot determine type of temp '{}' in xform:\n{}"
                         .format(v, self))

--- a/lib/cretonne/meta/gen_instr.py
+++ b/lib/cretonne/meta/gen_instr.py
@@ -321,8 +321,8 @@ def get_constraint(op, ctrl_typevar, type_sets):
     tv = op.typevar
 
     # A concrete value type.
-    if tv.singleton_type:
-        return 'Concrete({})'.format(tv.singleton_type.rust_name())
+    if tv.singleton_type():
+        return 'Concrete({})'.format(tv.singleton_type().rust_name())
 
     if tv.free_typevar() is not ctrl_typevar:
         assert not tv.is_derived


### PR DESCRIPTION
This PR only adds forward image computations of typesets. This allows us to compute the concrete typeset for any derived type var. As a result, TypeVar.singleton_type can be computed from the typeset for any type var. Therefore we can replace it with a identically named function. This (i think) takes care of the following todo in TypeVar.constrain_type():

-            # TODO: What if a.type_set becomes empty?
-            if not a.singleton_type:
-                a.singleton_type = b.singleton_type
