### PR TITLE
Cleanup for several comments in PR #110

### DIFF
--- a/lib/cretonne/meta/cdsl/test_ti.py
+++ b/lib/cretonne/meta/cdsl/test_ti.py
@@ -62,7 +62,7 @@ def agree(me, other):
             if m[me[tv]] != other[tv]:
                 return False
 
-    # Tranlsate our constraints using m, and sort
+    # Translate our constraints using m, and sort
     me_equiv_constr = [(subst(a, m), subst(b, m)) for (a, b) in me.constraints]
     me_equiv_constr = sorted([sort_constr(x) for x in me_equiv_constr])
 
@@ -76,7 +76,7 @@ def agree(me, other):
 def check_typing(got_or_err, expected, symtab=None):
     # type: (TypingOrError, Tuple[VarMap, ConstraintList], Dict[str, Var]) -> None # noqa
     """
-    Check that a the typying we received (got_or_err) complies with the
+    Check that a the typing we received (got_or_err) complies with the
     expected typing (expected). If symtab is specified, substitute the Vars in
     expected using symtab first (used when checking type inference on XForms)
     """
@@ -409,7 +409,7 @@ class TestXForm(TypeCheckingBaseTest):
 
             # If there are no free_typevars, this is a non-polymorphic pattern.
             # There should be only one possible concrete typing.
-            if (len(xform.free_typevars) == 0):
+            if (len(xform.ti.free_typevars()) == 0):
                 assert len(concrete_typings_list) == 1
                 continue
 
@@ -423,7 +423,7 @@ class TestXForm(TypeCheckingBaseTest):
                 theoretical_num_typings =\
                     reduce(lambda x, y:    x*y,
                            [tv.get_typeset().size()
-                            for tv in xform.free_typevars], 1)
+                            for tv in xform.ti.free_typevars()], 1)
                 assert len(concrete_typings_list) < theoretical_num_typings
 
             # Check the validity of each individual concrete typing against the

--- a/lib/cretonne/meta/cdsl/test_typevar.py
+++ b/lib/cretonne/meta/cdsl/test_typevar.py
@@ -127,7 +127,6 @@ class TestTypeSet(TestCase):
 
     def test_preimage(self):
         t = TypeSet(lanes=(1, 1), ints=(8, 8), floats=(32, 32))
-        self.assertEqual(t, t.preimage(TypeVar.SAMEAS))
 
         # LANEOF
         self.assertEqual(TypeSet(lanes=True, ints=(8, 8), floats=(32, 32)),
@@ -217,12 +216,11 @@ class TestTypeVar(TestCase):
         self.assertEqual(len(x.type_set.bools), 0)
 
     def test_stress_constrain_types(self):
-        # Get all 49 possible derived vars of length 2. Since we have SAMEAS
-        # this includes singly derived and non-derived vars
-        funcs = [TypeVar.SAMEAS, TypeVar.LANEOF,
+        # Get all 43 possible derived vars of length up to 2
+        funcs = [TypeVar.LANEOF,
                  TypeVar.ASBOOL, TypeVar.HALFVECTOR, TypeVar.DOUBLEVECTOR,
                  TypeVar.HALFWIDTH, TypeVar.DOUBLEWIDTH]
-        v = list(product(*[funcs, funcs]))
+        v = [()] + [(x,) for x in funcs] + list(product(*[funcs, funcs]))
 
         # For each pair of derived variables
         for (i1, i2) in product(v, v):

--- a/lib/cretonne/meta/cdsl/xform.py
+++ b/lib/cretonne/meta/cdsl/xform.py
@@ -106,14 +106,14 @@ class XForm(object):
 
         # Sanity: The set of inferred free typevars should be a subset of the
         # TVs corresponding to Vars appearing in src
-        self.free_typevars = self.ti.free_typevars()
+        free_typevars = set(self.ti.free_typevars())
         src_vars = set(self.inputs).union(
             [x for x in self.defs if not x.is_temp()])
         src_tvs = set([v.get_typevar() for v in src_vars])
-        if (not self.free_typevars.issubset(src_tvs)):
+        if (not free_typevars.issubset(src_tvs)):
             raise AssertionError(
                 "Some free vars don't appear in src - {}"
-                .format(self.free_typevars.difference(src_tvs)))
+                .format(free_typevars.difference(src_tvs)))
 
         # Update the type vars for each Var to their inferred values
         for v in self.inputs + self.defs:


### PR DESCRIPTION
This PR addresses several comments in PR #110. Concretely:

Cleanup typos;
Remove SAMEAS;
More descriptive rank comments;
Introduce explicit sorting in free_typevars()
Move TV safety asserts in TypeVar.derived() - as per the comment in TypeEnv.normalize_tv about cancellation, whenever we create a TypeVar we must assert that there is no under/overflow. To make sure this happen _always_ move the safety checks to TypeVar.derived(), which is called along all paths.