### PR TITLE
Emit runtime type checks in legalizer.rs

### DIFF
--- a/lib/cretonne/meta/cdsl/xform.py
+++ b/lib/cretonne/meta/cdsl/xform.py
@@ -41,6 +41,14 @@ class Rtl(object):
         # type: (*DefApply) -> None
         self.rtl = tuple(map(canonicalize_defapply, args))
 
+    def copy(self, m):
+        # type: (Dict[Var, Var]) -> Rtl
+        """
+        Return a copy of this rtl with all Vars substituted with copies or
+        according to m. Update m as neccessary.
+        """
+        return Rtl(*[d.copy(m) for d in self.rtl])
+
 
 class XForm(object):
     """

--- a/lib/cretonne/meta/gen_legalizer.py
+++ b/lib/cretonne/meta/gen_legalizer.py
@@ -15,13 +15,14 @@ from cdsl.ti import ti_rtl, TypeEnv, get_type_env, ConstrainTVsEqual,\
     ConstrainTVInTypeset
 from unique_table import UniqueTable
 from gen_instr import gen_typesets_table
+from cdsl.typevar import TypeVar
 
 try:
     from typing import Sequence, List, Dict # noqa
     from cdsl.isa import TargetISA  # noqa
     from cdsl.ast import Def  # noqa
     from cdsl.xform import XForm, XFormGroup  # noqa
-    from cdsl.typevar import TypeVar, TypeSet # noqa
+    from cdsl.typevar import TypeSet # noqa
     from cdsl.ti import TypeConstraint # noqa
 except ImportError:
     pass

--- a/lib/cretonne/meta/gen_legalizer.py
+++ b/lib/cretonne/meta/gen_legalizer.py
@@ -11,14 +11,108 @@ from __future__ import absolute_import
 from srcgen import Formatter
 from base import legalize, instructions
 from cdsl.ast import Var
+from cdsl.ti import ti_rtl, TypeEnv, get_type_env, ConstrainTVsEqual,\
+    ConstrainTVInTypeset
+from unique_table import UniqueTable
+from gen_instr import gen_typesets_table
 
 try:
-    from typing import Sequence  # noqa
+    from typing import Sequence, List, Dict # noqa
     from cdsl.isa import TargetISA  # noqa
     from cdsl.ast import Def  # noqa
     from cdsl.xform import XForm, XFormGroup  # noqa
+    from cdsl.typevar import TypeVar, TypeSet # noqa
+    from cdsl.ti import TypeConstraint # noqa
 except ImportError:
     pass
+
+
+def get_runtime_typechecks(xform):
+    # type: (XForm) -> List[TypeConstraint]
+    """
+    Given a XForm build a list of runtime type checks neccessary to determine
+    if it applies. We have 2 types of runtime checks:
+        1) typevar tv belongs to typeset T - needed for free tvs whose
+               typeset is constrainted by their use in the dst pattern
+
+        2) tv1 == tv2 where tv1 and tv2 are derived TVs - caused by unification
+                of non-bijective functions
+    """
+    check_l = []  # type: List[TypeConstraint]
+
+    # 1) Perform ti only on the source RTL. Accumulate any free tvs that have a
+    #    different inferred type in src, compared to the type inferred for both
+    #    src and dst.
+    symtab = {}  # type: Dict[Var, Var]
+    src_copy = xform.src.copy(symtab)
+    src_typenv = get_type_env(ti_rtl(src_copy, TypeEnv()))
+
+    for v in xform.ti.vars:
+        if not v.has_free_typevar():
+            continue
+
+        # In rust the local variable containing a free TV associated with var v
+        # has name typeof_v. We rely on the python TVs having the same name.
+        assert "typeof_{}".format(v) == xform.ti[v].name
+
+        if v not in symtab:
+            # We can have singleton vars defined only on dst. Ignore them
+            assert v.get_typevar().singleton_type() is not None
+            continue
+
+        src_ts = src_typenv[symtab[v]].get_typeset()
+        xform_ts = xform.ti[v].get_typeset()
+
+        assert xform_ts.issubset(src_ts)
+        if src_ts != xform_ts:
+            check_l.append(ConstrainTVInTypeset(xform.ti[v], xform_ts))
+
+    # 2,3) Add any constraints that appear in xform.ti
+    check_l.extend(xform.ti.constraints)
+
+    return check_l
+
+
+def emit_runtime_typecheck(check, fmt, type_sets):
+    # type: (TypeConstraint, Formatter, UniqueTable) -> None
+    """
+    Emit rust code for the given check.
+    """
+    def build_derived_expr(tv):
+        # type: (TypeVar) -> str
+        if not tv.is_derived:
+            assert tv.name.startswith('typeof_')
+            return tv.name
+
+        f = {
+            TypeVar.LANEOF: 'LaneOf',
+            TypeVar.ASBOOL: 'AsBool',
+            TypeVar.HALFWIDTH: 'HalfWidth',
+            TypeVar.DOUBLEWIDTH: 'DoubleWidth',
+            TypeVar.HALFVECTOR: 'HalfVector',
+            TypeVar.DOUBLEVECTOR: 'DoubleVector',
+        }[tv.derived_func]
+
+        return 'Type.transform({}, {})'\
+            .format(build_derived_expr(tv.base), f)
+
+    if (isinstance(check, ConstrainTVInTypeset)):
+        tv = check.tv.name
+        if check.ts not in type_sets.index:
+            type_sets.add(check.ts)
+        ts = type_sets.index[check.ts]
+
+        fmt.comment("{} must belong to {}".format(tv, check.ts))
+        with fmt.indented('if !TYPE_SETS[{}].contains({}) {{'.format(ts, tv),
+                          '};'):
+            fmt.line('return false;')
+    elif (isinstance(check, ConstrainTVsEqual)):
+        tv1 = build_derived_expr(check.tv1)
+        tv2 = build_derived_expr(check.tv2)
+        with fmt.indented('if {} != {} {{'.format(tv1, tv2), '};'):
+            fmt.line('return false;')
+    else:
+        assert False, "Unknown check {}".format(check)
 
 
 def unwrap_inst(iref, node, fmt):
@@ -183,8 +277,8 @@ def emit_dst_inst(node, fmt):
             fmt.line('pos.next_inst();')
 
 
-def gen_xform(xform, fmt):
-    # type: (XForm, Formatter) -> None
+def gen_xform(xform, fmt, type_sets):
+    # type: (XForm, Formatter, UniqueTable) -> None
     """
     Emit code for `xform`, assuming the the opcode of xform's root instruction
     has already been matched.
@@ -203,6 +297,10 @@ def gen_xform(xform, fmt):
     instp = xform.src.rtl[0].expr.inst_predicate()
     assert instp is None, "Instruction predicates not supported in legalizer"
 
+    # Emit any runtime checks. TODO: Does this make the above code obsolete?
+    for check in get_runtime_typechecks(xform):
+        emit_runtime_typecheck(check, fmt, type_sets)
+
     # Emit the destination pattern.
     for dst in xform.dst.rtl:
         emit_dst_inst(dst, fmt)
@@ -213,8 +311,8 @@ def gen_xform(xform, fmt):
         fmt.line('assert_eq!(pos.remove_inst(), inst);')
 
 
-def gen_xform_group(xgrp, fmt):
-    # type: (XFormGroup, Formatter) -> None
+def gen_xform_group(xgrp, fmt, type_sets):
+    # type: (XFormGroup, Formatter, UniqueTable) -> None
     fmt.doc_comment("Legalize the instruction pointed to by `pos`.")
     fmt.line('#[allow(unused_variables,unused_assignments)]')
     with fmt.indented(
@@ -231,7 +329,7 @@ def gen_xform_group(xgrp, fmt):
                 inst = xform.src.rtl[0].expr.inst
                 with fmt.indented(
                         'Opcode::{} => {{'.format(inst.camel_name), '}'):
-                    gen_xform(xform, fmt)
+                    gen_xform(xform, fmt, type_sets)
             # We'll assume there are uncovered opcodes.
             fmt.line('_ => return false,')
         fmt.line('true')
@@ -240,6 +338,11 @@ def gen_xform_group(xgrp, fmt):
 def generate(isas, out_dir):
     # type: (Sequence[TargetISA], str) -> None
     fmt = Formatter()
-    gen_xform_group(legalize.narrow, fmt)
-    gen_xform_group(legalize.expand, fmt)
+    # Table of TypeSet instances
+    type_sets = UniqueTable()
+
+    gen_xform_group(legalize.narrow, fmt, type_sets)
+    gen_xform_group(legalize.expand, fmt, type_sets)
+
+    gen_typesets_table(fmt, type_sets)
     fmt.update_file('legalizer.rs', out_dir)

--- a/lib/cretonne/meta/test_gen_legalizer.py
+++ b/lib/cretonne/meta/test_gen_legalizer.py
@@ -1,0 +1,144 @@
+import doctest
+import gen_legalizer
+from unittest import TestCase
+from srcgen import Formatter
+from gen_legalizer import get_runtime_typechecks, emit_runtime_typecheck
+from base.instructions import vselect, vsplit, isplit, iconcat, vconcat, \
+    iconst, b1, icmp, copy # noqa
+from base.legalize import narrow, expand # noqa
+from base.immediates import intcc # noqa
+from cdsl.typevar import TypeVar, TypeSet
+from cdsl.ast import Var, Def # noqa
+from cdsl.xform import Rtl, XForm # noqa
+from cdsl.ti import ti_rtl, subst, TypeEnv, get_type_env # noqa
+from unique_table import UniqueTable
+from functools import reduce
+
+try:
+    from typing import Callable, TYPE_CHECKING, Iterable, Any # noqa
+    if TYPE_CHECKING:
+        CheckProducer = Callable[[UniqueTable], str]
+except ImportError:
+    TYPE_CHECKING = False
+
+
+def load_tests(loader, tests, ignore):
+    # type: (Any, Any, Any) -> Any
+    tests.addTests(doctest.DocTestSuite(gen_legalizer))
+    return tests
+
+
+def format_check(typesets, s, *args):
+    # type: (...) -> str
+    def transform(x):
+        # type: (Any) -> str
+        if isinstance(x, TypeSet):
+            return str(typesets.index[x])
+        elif isinstance(x, TypeVar):
+            assert not x.is_derived
+            return x.name
+        else:
+            return str(x)
+
+    dummy_s = s  # type: str
+    args = tuple(map(lambda x:  transform(x), args))
+    return dummy_s.format(*args)
+
+
+def typeset_check(v, ts):
+    # type: (Var, TypeSet) -> CheckProducer
+    return lambda typesets: format_check(
+        typesets,
+        'if !TYPE_SETS[{}].contains(typeof_{}) ' +
+        '{{\n    return false;\n}};\n', ts, v)
+
+
+def equiv_check(tv1, tv2):
+    # type: (TypeVar, TypeVar) -> CheckProducer
+    return lambda typesets: format_check(
+        typesets,
+        'if Type.transform({}, AsBool) != Type.transform({}, AsBool) ' +
+        '{{\n    return false;\n}};\n', tv1, tv2)
+
+
+def sequence(*args):
+    # type: (...) -> CheckProducer
+    dummy = args  # type: Iterable[CheckProducer]
+
+    def sequenceF(typesets):
+        # type: (UniqueTable) -> str
+        def strconcat(acc, el):
+            # type: (str, CheckProducer) -> str
+            return acc + el(typesets)
+
+        return reduce(strconcat, dummy, "")
+    return sequenceF
+
+
+class TestRuntimeChecks(TestCase):
+
+    def setUp(self):
+        # type: () -> None
+        self.v0 = Var("v0")
+        self.v1 = Var("v1")
+        self.v2 = Var("v2")
+        self.v3 = Var("v3")
+        self.v4 = Var("v4")
+        self.v5 = Var("v5")
+        self.v6 = Var("v6")
+        self.v7 = Var("v7")
+        self.v8 = Var("v8")
+        self.v9 = Var("v9")
+        self.imm0 = Var("imm0")
+        self.IxN_nonscalar = TypeVar("IxN_nonscalar", "", ints=True,
+                                     scalars=False, simd=True)
+        self.TxN = TypeVar("TxN", "", ints=True, bools=True, floats=True,
+                           scalars=False, simd=True)
+        self.b1 = TypeVar.singleton(b1)
+
+    def check_yo_check(self, xform, expected_f):
+        # type: (XForm, CheckProducer) -> None
+        fmt = Formatter()
+        type_sets = UniqueTable()
+        for check in get_runtime_typechecks(xform):
+            emit_runtime_typecheck(check, fmt, type_sets)
+
+        # Remove comments
+        got = "".join([l for l in fmt.lines if not l.strip().startswith("//")])
+        expected = expected_f(type_sets)
+        self.assertEqual(got, expected)
+
+    def test_width_check(self):
+        # type: () -> None
+        x = XForm(Rtl(self.v0 << copy(self.v1)),
+                  Rtl((self.v2, self.v3) << isplit(self.v1),
+                      self.v0 << iconcat(self.v2, self.v3)))
+
+        WideInt = TypeSet(lanes=(1, 256), ints=(16, 64))
+        self.check_yo_check(x, typeset_check(self.v1, WideInt))
+
+    def test_lanes_check(self):
+        # type: () -> None
+        x = XForm(Rtl(self.v0 << copy(self.v1)),
+                  Rtl((self.v2, self.v3) << vsplit(self.v1),
+                      self.v0 << vconcat(self.v2, self.v3)))
+
+        WideVec = TypeSet(lanes=(2, 256), ints=(8, 64), floats=(32, 64),
+                          bools=(1, 64))
+        self.check_yo_check(x, typeset_check(self.v1, WideVec))
+
+    def test_vselect_imm(self):
+        # type: () -> None
+        ts = TypeSet(lanes=(2, 256), ints=(8, 64),
+                     floats=(32, 64), bools=(8, 64))
+        r = Rtl(
+                self.v0 << iconst(self.imm0),
+                self.v1 << icmp(intcc.eq, self.v2, self.v0),
+                self.v5 << vselect(self.v1, self.v3, self.v4),
+        )
+        x = XForm(r, r)
+
+        self.check_yo_check(
+            x, sequence(typeset_check(self.v3, ts),
+                        equiv_check(self.v2.get_typevar(),
+                                    self.v3.get_typevar())))

--- a/lib/cretonne/meta/test_gen_legalizer.py
+++ b/lib/cretonne/meta/test_gen_legalizer.py
@@ -57,7 +57,8 @@ def equiv_check(tv1, tv2):
     # type: (TypeVar, TypeVar) -> CheckProducer
     return lambda typesets: format_check(
         typesets,
-        'if Type.transform({}, AsBool) != Type.transform({}, AsBool) ' +
+        'if Some({}).map(|t: Type| -> t.as_bool()) != ' +
+        'Some({}).map(|t: Type| -> t.as_bool()) ' +
         '{{\n    return false;\n}};\n', tv1, tv2)
 
 

--- a/lib/cretonne/src/ir/instructions.rs
+++ b/lib/cretonne/src/ir/instructions.rs
@@ -506,10 +506,14 @@ type BitSet16 = BitSet<u16>;
 /// A value type set describes the permitted set of types for a type variable.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ValueTypeSet {
-    lanes: BitSet16,
-    ints: BitSet8,
-    floats: BitSet8,
-    bools: BitSet8,
+    /// Allowed lane sizes
+    pub lanes: BitSet16,
+    /// Allowed int widths
+    pub ints: BitSet8,
+    /// Allowed float widths
+    pub floats: BitSet8,
+    /// Allowed bool widths
+    pub bools: BitSet8,
 }
 
 impl ValueTypeSet {

--- a/lib/cretonne/src/ir/types.rs
+++ b/lib/cretonne/src/ir/types.rs
@@ -35,6 +35,22 @@ pub const VOID: Type = Type(0);
 // 512-bit SIMD vectors.
 include!(concat!(env!("OUT_DIR"), "/types.rs"));
 
+/// Possible derivation functions for types. Used in runtime typechecking
+pub enum DerivedFunctions {
+    /// Corresponds to as_bool() derived function
+    AsBool,
+    /// Corresponds to lane_of() derived function
+    LaneOf,
+    /// Corresponds to half_width() derived function
+    HalfWidth,
+    /// Corresponds to double_width() derived function
+    DoubleWidth,
+    /// Corresponds to half_vector() derived function
+    HalfVector,
+    /// Corresponds to double_vector() derived function
+    DoubleVector,
+}
+
 impl Type {
     /// Get the lane type of this SIMD vector type.
     ///
@@ -235,6 +251,24 @@ impl Type {
     /// Index of this type, for use with hash tables etc.
     pub fn index(self) -> usize {
         self.0 as usize
+    }
+
+
+    /// Transform this type with the specified derived function
+    pub fn transform(maybe_t: Option<Type>, f: DerivedFunctions) -> Option<Type> {
+        match maybe_t {
+            None => None,
+            Some(t) => {
+                match f {
+                    DerivedFunctions::AsBool => Some(t.as_bool()),
+                    DerivedFunctions::LaneOf => Some(t.lane_type()),
+                    DerivedFunctions::HalfWidth => t.half_width(),
+                    DerivedFunctions::DoubleWidth => t.double_width(),
+                    DerivedFunctions::HalfVector => t.half_vector(),
+                    DerivedFunctions::DoubleVector => t.by(2),
+                }
+            }
+        }
     }
 }
 

--- a/lib/cretonne/src/ir/types.rs
+++ b/lib/cretonne/src/ir/types.rs
@@ -35,22 +35,6 @@ pub const VOID: Type = Type(0);
 // 512-bit SIMD vectors.
 include!(concat!(env!("OUT_DIR"), "/types.rs"));
 
-/// Possible derivation functions for types. Used in runtime typechecking
-pub enum DerivedFunctions {
-    /// Corresponds to as_bool() derived function
-    AsBool,
-    /// Corresponds to lane_of() derived function
-    LaneOf,
-    /// Corresponds to half_width() derived function
-    HalfWidth,
-    /// Corresponds to double_width() derived function
-    DoubleWidth,
-    /// Corresponds to half_vector() derived function
-    HalfVector,
-    /// Corresponds to double_vector() derived function
-    DoubleVector,
-}
-
 impl Type {
     /// Get the lane type of this SIMD vector type.
     ///
@@ -251,24 +235,6 @@ impl Type {
     /// Index of this type, for use with hash tables etc.
     pub fn index(self) -> usize {
         self.0 as usize
-    }
-
-
-    /// Transform this type with the specified derived function
-    pub fn transform(maybe_t: Option<Type>, f: DerivedFunctions) -> Option<Type> {
-        match maybe_t {
-            None => None,
-            Some(t) => {
-                match f {
-                    DerivedFunctions::AsBool => Some(t.as_bool()),
-                    DerivedFunctions::LaneOf => Some(t.lane_type()),
-                    DerivedFunctions::HalfWidth => t.half_width(),
-                    DerivedFunctions::DoubleWidth => t.double_width(),
-                    DerivedFunctions::HalfVector => t.half_vector(),
-                    DerivedFunctions::DoubleVector => t.by(2),
-                }
-            }
-        }
     }
 }
 

--- a/lib/cretonne/src/legalizer/mod.rs
+++ b/lib/cretonne/src/legalizer/mod.rs
@@ -18,6 +18,8 @@ use flowgraph::ControlFlowGraph;
 use ir::{Function, Cursor, DataFlowGraph, InstructionData, Opcode, InstBuilder};
 use ir::condcodes::IntCC;
 use isa::{TargetIsa, Legalize};
+use bitset::BitSet;
+use ir::instructions::ValueTypeSet;
 
 mod boundary;
 mod split;


### PR DESCRIPTION
This PR emits runtime type checks for patters in legalizer.rs. Specifically it emits checks under 2 conditions:

1) A most-general type of a var v in a XForm(r1,r2) is more constraint then its most general type in just r1. For these cases, the fact that r1 is valid RTL is not sufficient to determine if XForm applies. We need to emit a check of the type typeof_v \in TS where TS is the typeset of v in the XForm

2) During type checking we may generate constraints between derived type vars that have non-bijective derived functions (e.g. as_bool). For those, we can't simply propagate the constraint up by constraining the root free variables, and instead must add an explicit runtime check.

In the future, we will add more  constraints. The for example we will need constraints for the following instructions:
      uextend/sextend - a constraint that the output type is wider than the input
      itrunc - a constraint that the output type is narrower than the input
      bitcast - TBD