### PR TITLE
Semantics

### DIFF
--- a/lib/cretonne/meta/base/semantics.py
+++ b/lib/cretonne/meta/base/semantics.py
@@ -2,11 +2,10 @@ from __future__ import absolute_import
 from semantics.primitives import prim_to_bv, prim_from_bv, bvsplit, bvconcat,\
     bvadd
 from .instructions import vsplit, vconcat, iadd
-from cdsl.xform import XForm, Rtl
+from cdsl.xform import Rtl
 from cdsl.ast import Var
 from cdsl.typevar import TypeSet
 from cdsl.ti import InTypeset
-import semantics.types # noqa
 
 x = Var('x')
 y = Var('y')
@@ -28,30 +27,32 @@ bvhi = Var('bvhi')
 ScalarTS = TypeSet(lanes=(1, 1), ints=True, floats=True, bools=True)
 
 vsplit.set_semantics(
-    XForm(Rtl((lo, hi) << vsplit(x)),
-          Rtl(bvx << prim_to_bv(x),
-              (bvlo, bvhi) << bvsplit(bvx),
-              lo << prim_from_bv(bvlo),
-              hi << prim_from_bv(bvhi))))
+    (lo, hi) << vsplit(x),
+    Rtl(
+        bvx << prim_to_bv(x),
+        (bvlo, bvhi) << bvsplit(bvx),
+        lo << prim_from_bv(bvlo),
+        hi << prim_from_bv(bvhi)
+    ))
 
 vconcat.set_semantics(
-    XForm(Rtl(x << vconcat(lo, hi)),
-          Rtl(bvlo << prim_to_bv(lo),
-              bvhi << prim_to_bv(hi),
-              bvx << bvconcat(bvlo, bvhi),
-              x << prim_from_bv(bvx))))
+    x << vconcat(lo, hi),
+    Rtl(
+        bvlo << prim_to_bv(lo),
+        bvhi << prim_to_bv(hi),
+        bvx << bvconcat(bvlo, bvhi),
+        x << prim_from_bv(bvx)
+    ))
 
-iadd.set_semantics([
-     XForm(Rtl(a << iadd(x, y)),
-           Rtl(bvx << prim_to_bv(x),
-               bvy << prim_to_bv(y),
-               bva << bvadd(bvx, bvy),
-               a << prim_from_bv(bva)),
-           constraints=[InTypeset(x.get_typevar(), ScalarTS)]),
-     XForm(Rtl(a << iadd(x, y)),
-           Rtl((xlo, xhi) << vsplit(x),
-               (ylo, yhi) << vsplit(y),
-               alo << iadd(xlo, ylo),
-               ahi << iadd(xhi, yhi),
-               a << vconcat(alo, ahi)))
-])
+iadd.set_semantics(
+    a << iadd(x, y),
+    (Rtl(bvx << prim_to_bv(x),
+         bvy << prim_to_bv(y),
+         bva << bvadd(bvx, bvy),
+         a << prim_from_bv(bva)),
+     [InTypeset(x.get_typevar(), ScalarTS)]),
+    Rtl((xlo, xhi) << vsplit(x),
+        (ylo, yhi) << vsplit(y),
+        alo << iadd(xlo, ylo),
+        ahi << iadd(xhi, yhi),
+        a << vconcat(alo, ahi)))

--- a/lib/cretonne/meta/base/semantics.py
+++ b/lib/cretonne/meta/base/semantics.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+from semantics.primitives import prim_to_bv, prim_from_bv, bvsplit, bvconcat,\
+    bvadd
+from .instructions import vsplit, vconcat, iadd
+from cdsl.xform import XForm, Rtl
+from cdsl.ast import Var
+from cdsl.typevar import TypeSet
+from cdsl.ti import InTypeset
+import semantics.types # noqa
+
+x = Var('x')
+y = Var('y')
+a = Var('a')
+xhi = Var('xhi')
+yhi = Var('yhi')
+ahi = Var('ahi')
+xlo = Var('xlo')
+ylo = Var('ylo')
+alo = Var('alo')
+lo = Var('lo')
+hi = Var('hi')
+bvx = Var('bvx')
+bvy = Var('bvy')
+bva = Var('bva')
+bvlo = Var('bvlo')
+bvhi = Var('bvhi')
+
+ScalarTS = TypeSet(lanes=(1, 1), ints=True, floats=True, bools=True)
+
+vsplit.set_semantics(
+    XForm(Rtl((lo, hi) << vsplit(x)),
+          Rtl(bvx << prim_to_bv(x),
+              (bvlo, bvhi) << bvsplit(bvx),
+              lo << prim_from_bv(bvlo),
+              hi << prim_from_bv(bvhi))))
+
+vconcat.set_semantics(
+    XForm(Rtl(x << vconcat(lo, hi)),
+          Rtl(bvlo << prim_to_bv(lo),
+              bvhi << prim_to_bv(hi),
+              bvx << bvconcat(bvlo, bvhi),
+              x << prim_from_bv(bvx))))
+
+iadd.set_semantics([
+     XForm(Rtl(a << iadd(x, y)),
+           Rtl(bvx << prim_to_bv(x),
+               bvy << prim_to_bv(y),
+               bva << bvadd(bvx, bvy),
+               a << prim_from_bv(bva)),
+           constraints=[InTypeset(x.get_typevar(), ScalarTS)]),
+     XForm(Rtl(a << iadd(x, y)),
+           Rtl((xlo, xhi) << vsplit(x),
+               (ylo, yhi) << vsplit(y),
+               alo << iadd(xlo, ylo),
+               ahi << iadd(xhi, yhi),
+               a << vconcat(alo, ahi)))
+])

--- a/lib/cretonne/meta/cdsl/ast.py
+++ b/lib/cretonne/meta/cdsl/ast.py
@@ -102,15 +102,17 @@ class Def(object):
 
     def vars(self):
         # type: () -> Set[Var]
-        """ Return the set of all Vars that appear in self"""
+        """Return the set of all Vars in self that correspond to SSA values"""
         return self.definitions().union(self.uses())
 
     def substitution(self, other, s):
         # type: (Def, VarMap) -> Optional[VarMap]
         """
         If the Defs self and other agree structurally, return a variable
-        substitution to transform self ot other. Two Defs agree structurally
-        if the contained Apply's agree structurally.
+        substitution to transform self to other. Otherwise return None. Two
+        Defs agree structurally if there exists a Var substitution, that can
+        transform one into the other. See Apply.substitution() for more
+        details.
         """
         s = self.expr.substitution(other.expr, s)
 
@@ -378,7 +380,7 @@ class Apply(Expr):
 
     def vars(self):
         # type: () -> Set[Var]
-        """ Return the set of all Vars that appear in self"""
+        """Return the set of all Vars in self that correspond to SSA values"""
         res = set()
         for i in self.inst.value_opnums:
             arg = self.args[i]
@@ -390,8 +392,8 @@ class Apply(Expr):
         # type: (Apply, VarMap) -> Optional[VarMap]
         """
         If the application self and other agree structurally, return a variable
-        substitution to transform self ot other. Two applications agree
-        structurally if:
+        substitution to transform self to other. Otherwise return None. Two
+        applications agree structurally if:
             1) They are over the same instruction
             2) Every Var v in self, maps to a single Var w in other. I.e for
                each use of v in self, w is used in the corresponding place in

--- a/lib/cretonne/meta/cdsl/ast.py
+++ b/lib/cretonne/meta/cdsl/ast.py
@@ -239,7 +239,7 @@ class Var(Expr):
                     'typeof_{}'.format(self),
                     'Type of the pattern variable `{}`'.format(self),
                     ints=True, floats=True, bools=True,
-                    scalars=True, simd=True)
+                    scalars=True, simd=True, bitvecs=True)
             self.original_typevar = tv
             self.typevar = tv
         return self.typevar

--- a/lib/cretonne/meta/cdsl/instructions.py
+++ b/lib/cretonne/meta/cdsl/instructions.py
@@ -7,14 +7,16 @@ from .formats import InstructionFormat
 
 try:
     from typing import Union, Sequence, List, Tuple, Any, TYPE_CHECKING  # noqa
+    from typing import Dict # noqa
     if TYPE_CHECKING:
-        from .ast import Expr, Apply  # noqa
+        from .ast import Expr, Apply, Var  # noqa
         from .typevar import TypeVar  # noqa
         from .ti import TypeConstraint  # noqa
         # List of operands for ins/outs:
         OpList = Union[Sequence[Operand], Operand]
         ConstrList = Union[Sequence[TypeConstraint], TypeConstraint]
         MaybeBoundInst = Union['Instruction', 'BoundInstruction']
+        VarTyping = Dict[Var, TypeVar]
 except ImportError:
     pass
 

--- a/lib/cretonne/meta/cdsl/instructions.py
+++ b/lib/cretonne/meta/cdsl/instructions.py
@@ -12,11 +12,12 @@ try:
         from .ast import Expr, Apply, Var  # noqa
         from .typevar import TypeVar  # noqa
         from .ti import TypeConstraint  # noqa
+        from .xform import XForm
         # List of operands for ins/outs:
         OpList = Union[Sequence[Operand], Operand]
         ConstrList = Union[Sequence[TypeConstraint], TypeConstraint]
         MaybeBoundInst = Union['Instruction', 'BoundInstruction']
-        VarTyping = Dict[Var, TypeVar]
+        InstructionSemantics = List[XForm]
 except ImportError:
     pass
 
@@ -119,6 +120,7 @@ class Instruction(object):
         self.outs = self._to_operand_tuple(outs)
         self.constraints = self._to_constraint_tuple(constraints)
         self.format = InstructionFormat.lookup(self.ins, self.outs)
+        self.semantics = None  # type: InstructionSemantics
 
         # Opcode number, assigned by gen_instr.py.
         self.number = None  # type: int
@@ -333,6 +335,17 @@ class Instruction(object):
         """
         from .ast import Apply  # noqa
         return Apply(self, args)
+
+    def set_semantics(self, sem):
+        # type: (Union[XForm, InstructionSemantics]) -> None
+        """Set our semantics."""
+        from semantics import verify_semantics
+
+        if not isinstance(sem, list):
+            sem = [sem]
+
+        verify_semantics(self, sem)
+        self.semantics = sem
 
 
 class BoundInstruction(object):

--- a/lib/cretonne/meta/cdsl/isa.py
+++ b/lib/cretonne/meta/cdsl/isa.py
@@ -5,6 +5,7 @@ from .predicates import And
 from .registers import RegClass, Register, Stack
 from .ast import Apply
 from .types import ValueType
+from .instructions import InstructionGroup
 
 # The typing module is only required by mypy, and we don't use these imports
 # outside type comments.
@@ -46,6 +47,10 @@ class TargetISA(object):
         self.regbanks = list()  # type: List[RegBank]
         self.regclasses = list()  # type: List[RegClass]
         self.legalize_codes = OrderedDict()  # type: OrderedDict[XFormGroup, int]  # noqa
+
+        assert InstructionGroup._current is None,\
+            "InstructionGroup {} is still open!"\
+            .format(InstructionGroup._current.name)
 
     def __str__(self):
         # type: () -> str

--- a/lib/cretonne/meta/cdsl/test_ti.py
+++ b/lib/cretonne/meta/cdsl/test_ti.py
@@ -13,7 +13,7 @@ from unittest import TestCase
 from functools import reduce
 
 try:
-    from .ti import TypeMap, ConstraintList, VarMap, TypingOrError # noqa
+    from .ti import TypeMap, ConstraintList, VarTyping, TypingOrError # noqa
     from typing import List, Dict, Tuple, TYPE_CHECKING, cast # noqa
 except ImportError:
     TYPE_CHECKING = False
@@ -61,7 +61,7 @@ def agree(me, other):
 
 
 def check_typing(got_or_err, expected, symtab=None):
-    # type: (TypingOrError, Tuple[VarMap, ConstraintList], Dict[str, Var]) -> None # noqa
+    # type: (TypingOrError, Tuple[VarTyping, ConstraintList], Dict[str, Var]) -> None # noqa
     """
     Check that a the typing we received (got_or_err) complies with the
     expected typing (expected). If symtab is specified, substitute the Vars in
@@ -93,7 +93,7 @@ def check_typing(got_or_err, expected, symtab=None):
 
 
 def check_concrete_typing_rtl(var_types, rtl):
-    # type: (VarMap, Rtl) -> None
+    # type: (VarTyping, Rtl) -> None
     """
     Check that a concrete type assignment var_types (Dict[Var, TypeVar]) is
     valid for an Rtl rtl.  Specifically check that:
@@ -136,7 +136,7 @@ def check_concrete_typing_rtl(var_types, rtl):
 
 
 def check_concrete_typing_xform(var_types, xform):
-    # type: (VarMap, XForm) -> None
+    # type: (VarTyping, XForm) -> None
     """
     Check a concrete type assignment var_types for an XForm xform
     """

--- a/lib/cretonne/meta/cdsl/types.py
+++ b/lib/cretonne/meta/cdsl/types.py
@@ -84,7 +84,10 @@ class ScalarType(ValueType):
         self._vectors = dict()  # type: Dict[int, VectorType]
         # Assign numbers starting from 1. (0 is VOID).
         ValueType.all_scalars.append(self)
-        self.number = len(ValueType.all_scalars)
+        # Numbers are only valid for Cretone types that get emitted to Rust.
+        # This excludes BVTypes
+        self.number = len([x for x in ValueType.all_scalars
+                           if not isinstance(x, BVType)])
         assert self.number < 16, 'Too many scalar types'
 
     def __repr__(self):
@@ -232,6 +235,37 @@ class BoolType(ScalarType):
         typ = ValueType.by_name('b{:d}'.format(bits))
         if TYPE_CHECKING:
             return cast(BoolType, typ)
+        else:
+            return typ
+
+    def lane_bits(self):
+        # type: () -> int
+        """Return the number of bits in a lane."""
+        return self.bits
+
+
+class BVType(ScalarType):
+    """A flat bitvector type. Used for semantics description only."""
+
+    def __init__(self, bits):
+        # type: (int) -> None
+        assert bits > 0, 'Must have positive number of bits'
+        super(BVType, self).__init__(
+                name='bv{:d}'.format(bits),
+                membytes=bits // 8,
+                doc="A bitvector type with {} bits.".format(bits))
+        self.bits = bits
+
+    def __repr__(self):
+        # type: () -> str
+        return 'BVType(bits={})'.format(self.bits)
+
+    @staticmethod
+    def with_bits(bits):
+        # type: (int) -> BVType
+        typ = ValueType.by_name('bv{:d}'.format(bits))
+        if TYPE_CHECKING:
+            return cast(BVType, typ)
         else:
             return typ
 

--- a/lib/cretonne/meta/cdsl/types.py
+++ b/lib/cretonne/meta/cdsl/types.py
@@ -59,6 +59,11 @@ class ValueType(object):
         """Return the number of lanes."""
         assert False, "Abstract"
 
+    def width(self):
+        # type: () -> int
+        """Return the total number of bits of an instance of this type."""
+        return self.lane_count() * self.lane_bits()
+
     def wider_or_equal(self, other):
         # type: (ValueType) -> bool
         """

--- a/lib/cretonne/meta/cdsl/types.py
+++ b/lib/cretonne/meta/cdsl/types.py
@@ -89,10 +89,7 @@ class ScalarType(ValueType):
         self._vectors = dict()  # type: Dict[int, VectorType]
         # Assign numbers starting from 1. (0 is VOID).
         ValueType.all_scalars.append(self)
-        # Numbers are only valid for Cretone types that get emitted to Rust.
-        # This excludes BVTypes
-        self.number = len([x for x in ValueType.all_scalars
-                           if not isinstance(x, BVType)])
+        self.number = len(ValueType.all_scalars)
         assert self.number < 16, 'Too many scalar types'
 
     def __repr__(self):
@@ -249,7 +246,7 @@ class BoolType(ScalarType):
         return self.bits
 
 
-class BVType(ScalarType):
+class BVType(ValueType):
     """A flat bitvector type. Used for semantics description only."""
 
     def __init__(self, bits):
@@ -268,7 +265,11 @@ class BVType(ScalarType):
     @staticmethod
     def with_bits(bits):
         # type: (int) -> BVType
-        typ = ValueType.by_name('bv{:d}'.format(bits))
+        name = 'bv{:d}'.format(bits)
+        if name not in ValueType._registry:
+            return BVType(bits)
+
+        typ = ValueType.by_name(name)
         if TYPE_CHECKING:
             return cast(BVType, typ)
         else:
@@ -278,3 +279,8 @@ class BVType(ScalarType):
         # type: () -> int
         """Return the number of bits in a lane."""
         return self.bits
+
+    def lane_count(self):
+        # type: () -> int
+        """Return the number of lane. For BVtypes always 1."""
+        return 1

--- a/lib/cretonne/meta/cdsl/typevar.py
+++ b/lib/cretonne/meta/cdsl/typevar.py
@@ -513,6 +513,13 @@ class TypeSet(object):
         assert len(types) == 1
         return types[0]
 
+    def widths(self):
+        # type: () -> Set[int]
+        """ Return a set of the widths of all possible types in self"""
+        scalar_w = self.ints.union(self.floats.union(self.bools))
+        scalar_w = scalar_w.union(self.bitvecs)
+        return set(w * l for l in self.lanes for w in scalar_w)
+
 
 class TypeVar(object):
     """

--- a/lib/cretonne/meta/cdsl/typevar.py
+++ b/lib/cretonne/meta/cdsl/typevar.py
@@ -501,7 +501,8 @@ class TypeSet(object):
             for bits in self.bools:
                 yield by(types.BoolType.with_bits(bits), nlanes)
             for bits in self.bitvecs:
-                yield by(types.BVType.with_bits(bits), nlanes)
+                assert nlanes == 1
+                yield types.BVType.with_bits(bits)
 
     def get_singleton(self):
         # type: () -> types.ValueType
@@ -572,10 +573,15 @@ class TypeVar(object):
     def singleton(typ):
         # type: (types.ValueType) -> TypeVar
         """Create a type variable that can only assume a single type."""
+        scalar = None  # type: ValueType
         if isinstance(typ, types.VectorType):
             scalar = typ.base
             lanes = (typ.lanes, typ.lanes)
         elif isinstance(typ, types.ScalarType):
+            scalar = typ
+            lanes = (1, 1)
+        else:
+            assert isinstance(typ, types.BVType)
             scalar = typ
             lanes = (1, 1)
 

--- a/lib/cretonne/meta/cdsl/xform.py
+++ b/lib/cretonne/meta/cdsl/xform.py
@@ -55,7 +55,7 @@ class Rtl(object):
 
     def vars(self):
         # type: () -> Set[Var]
-        """ Return the set of all Vars that appear in self"""
+        """Return the set of all Vars in self that correspond to SSA values"""
         return reduce(lambda x, y:  x.union(y),
                       [d.vars() for d in self.rtl],
                       set([]))

--- a/lib/cretonne/meta/isa/intel/instructions.py
+++ b/lib/cretonne/meta/isa/intel/instructions.py
@@ -43,3 +43,5 @@ sdivmodx = Instruction(
         Return both quotient and remainder.
         """,
         ins=(nlo, nhi, d), outs=(q, r), can_trap=True)
+
+GROUP.close()

--- a/lib/cretonne/meta/semantics/__init__.py
+++ b/lib/cretonne/meta/semantics/__init__.py
@@ -1,0 +1,55 @@
+"""Definitions for the semantics segment of the Cretonne language."""
+from cdsl.ti import TypeEnv, ti_rtl, get_type_env
+
+try:
+    from typing import List, Dict, Tuple # noqa
+    from cdsl.ast import Var # noqa
+    from cdsl.xform import XForm # noqa
+    from cdsl.ti import VarTyping # noqa
+    from cdsl.instructions import Instruction, InstructionSemantics # noqa
+except ImportError:
+    pass
+
+
+def verify_semantics(inst, sem):
+    # type: (Instruction, InstructionSemantics) -> None
+    """
+    Verify that the semantics sem correctly describes the instruction inst.
+    This involves checking that:
+        1) For all XForms x \in sem, x.src consists of a single instance of
+           inst
+        2) For any possible concrete typing of inst there is exactly 1 XForm x
+           in sem that applies.
+    """
+    # 1) The source rtl is always a single instance of inst.
+    for xform in sem:
+        assert len(xform.src.rtl) == 1 and\
+            xform.src.rtl[0].expr.inst == inst,\
+            "XForm {} doesn't describe instruction {}."\
+            .format(xform, inst)
+
+    # 2) Any possible typing for the instruction should be covered by
+    #    exactly ONE semantic XForm
+    inst_rtl = sem[0].src
+    typenv = get_type_env(ti_rtl(inst_rtl, TypeEnv()))
+
+    # This bit is awkward. Concrete typing is defined in terms of the vars
+    # of one Rtl. We arbitrarily picked that Rtl to be sem[0].src. For any
+    # other XForms in sem, we must build a substitution form
+    # sem[0].src->sem[N].src, before we can check if sem[N] permits one of
+    # the concrete typings of our Rtl.
+    # TODO: Can this be made cleaner?
+    subst = [inst_rtl.substitution(x.src, {}) for x in sem]
+    assert not any(x is None for x in subst)
+    sub_sem = list(zip(subst, sem))  # type: List[Tuple[Dict[Var, Var], XForm]] # noqa
+
+    def subst_typing(typing, sub):
+        # type: (VarTyping, Dict[Var, Var]) -> VarTyping
+        return {sub[v]: tv for (v, tv) in typing.items()}
+
+    for t in typenv.concrete_typings():
+        matching_xforms = [x for (s, x) in sub_sem
+                           if x.ti.permits(subst_typing(t, s))]
+        assert len(matching_xforms) == 1,\
+            ("Possible typing {} of {} not matched by exactly one case " +
+             ": {}").format(t, inst, matching_xforms)

--- a/lib/cretonne/meta/semantics/elaborate.py
+++ b/lib/cretonne/meta/semantics/elaborate.py
@@ -7,11 +7,12 @@ from .primitives import GROUP as PRIMITIVES, prim_to_bv, prim_from_bv
 from cdsl.ti import ti_rtl, TypeEnv, get_type_env
 from cdsl.typevar import TypeVar
 from cdsl.xform import Rtl
+from cdsl.ast import Var
 
 try:
     from typing import TYPE_CHECKING, Dict, Union, List, Set, Tuple # noqa
     from cdsl.xform import XForm # noqa
-    from cdsl.ast import Var, Def, VarMap # noqa
+    from cdsl.ast import Def, VarMap # noqa
     from cdsl.ti import VarTyping # noqa
 except ImportError:
     TYPE_CHECKING = False

--- a/lib/cretonne/meta/semantics/elaborate.py
+++ b/lib/cretonne/meta/semantics/elaborate.py
@@ -81,6 +81,7 @@ def find_matching_xform(d):
 
     for x in d.expr.inst.semantics:
         subst = d.substitution(x.src.rtl[0], {})
+        assert subst is not None
 
         if x.ti.permits({subst[v]: tv for (v, tv) in typing.items()}):
             res.append(x)

--- a/lib/cretonne/meta/semantics/elaborate.py
+++ b/lib/cretonne/meta/semantics/elaborate.py
@@ -1,0 +1,170 @@
+"""
+Tools to elaborate a given Rtl with concrete types into its semantically
+equivalent primitive version. Its elaborated primitive version contains only
+primitive cretonne instructions, which map well to SMTLIB functions.
+"""
+from .primitives import GROUP as PRIMITIVES, prim_to_bv, prim_from_bv
+from cdsl.ti import ti_rtl, TypeEnv, get_type_env
+from cdsl.typevar import TypeVar
+
+try:
+    from typing import TYPE_CHECKING, Dict, Union, List, Set, Tuple # noqa
+    from cdsl.xform import Rtl, XForm # noqa
+    from cdsl.ast import Var, Def, VarMap # noqa
+    from cdsl.ti import VarTyping # noqa
+except ImportError:
+    TYPE_CHECKING = False
+
+
+def is_rtl_concrete(r):
+    # type: (Rtl) -> bool
+    """Return True iff every Var in the Rtl r has a single type."""
+    return all(v.get_typevar().singleton_type() is not None for v in r.vars())
+
+
+def cleanup_concrete_rtl(r):
+    # type: (Rtl) -> Rtl
+    """
+    Given an Rtl r
+    1) assert that there is only 1 possible concrete typing T for r
+    2) Assign a singleton TV with the single type t \in T for each Var v \in r
+    """
+    # 1) Infer the types of any of the remaining vars in res
+    typenv = get_type_env(ti_rtl(r, TypeEnv()))
+    typenv.normalize()
+    typenv = typenv.extract()
+
+    # 2) Make sure there is only one possible type assignment
+    typings = list(typenv.concrete_typings())
+    assert len(typings) == 1
+    typing = typings[0]
+
+    # 3) Assign the only possible type to each variable.
+    for v in typenv.vars:
+        if v.get_typevar().singleton_type() is not None:
+            continue
+
+        v.set_typevar(TypeVar.singleton(typing[v].singleton_type()))
+
+    return r
+
+
+def apply(r, x, suffix=None):
+    # type: (Rtl, XForm, str) -> Rtl
+    """
+    Given a concrete Rtl r and XForm x, s.t. r matches x.src, return the
+    corresponding concrete x.dst. If suffix is provided, any temporary defs are
+    renamed with '.suffix' appended to their old name.
+    """
+    assert is_rtl_concrete(r)
+    s = x.src.substitution(r, {})  # type: VarMap
+    assert s is not None
+
+    if (suffix is not None):
+        for v in x.dst.vars():
+            if v.is_temp():
+                assert v not in s
+                s[v] = Var(v.name + '.' + suffix)
+
+    dst = x.dst.copy(s)
+    return cleanup_concrete_rtl(dst)
+
+
+def find_matching_xform(d):
+    # type: (Def) -> XForm
+    """
+    Given a concrete Def d, find the unique semantic XForm x in
+    d.expr.inst.semantics that applies to it.
+    """
+    res = []  # type: List[XForm]
+    typing = {v:   v.get_typevar() for v in d.vars()}  # type: VarTyping
+
+    for x in d.expr.inst.semantics:
+        subst = d.substitution(x.src.rtl[0], {})
+
+        if x.ti.permits({subst[v]: tv for (v, tv) in typing.items()}):
+            res.append(x)
+
+    assert len(res) == 1
+    return res[0]
+
+
+def elaborate(r):
+    # type: (Rtl) -> Rtl
+    """
+    Given an Rtl r, return a semantically equivalent Rtl r1 consisting only
+    primitive instructions.
+    """
+    fp = False
+    primitives = set(PRIMITIVES.instructions)
+    idx = 0
+
+    while not fp:
+        assert is_rtl_concrete(r)
+        new_defs = []  # type: List[Def]
+        fp = True
+
+        for d in r.rtl:
+            inst = d.expr.inst
+
+            if (inst not in primitives):
+                transformed = apply(Rtl(d), find_matching_xform(d), str(idx))
+                idx += 1
+                new_defs.extend(transformed.rtl)
+                fp = False
+            else:
+                new_defs.append(d)
+
+        r.rtl = tuple(new_defs)
+
+    return r
+
+
+def cleanup_semantics(r, outputs):
+    # type: (Rtl, Set[Var]) -> Rtl
+    """
+    The elaboration process creates a lot of redundant instruction pairs of the
+    shape:
+
+        a.0 << prim_from_bv(bva.0)
+        ...
+        bva.1 << prim_to_bv(a.0)
+        ...
+
+    Contract these to ease manual inspection.
+    """
+    new_defs = []  # type: List[Def]
+    subst_m = {v: v for v in r.vars()}  # type: VarMap
+    definition = {}  # type: Dict[Var, Def]
+
+    # Pass 1: Remove redundant prim_to_bv
+    for d in r.rtl:
+        inst = d.expr.inst
+
+        if (inst == prim_to_bv):
+            if d.expr.args[0] in definition:
+                assert isinstance(d.expr.args[0], Var)
+                def_loc = definition[d.expr.args[0]]
+
+                if def_loc.expr.inst == prim_from_bv:
+                    assert isinstance(def_loc.expr.args[0], Var)
+                    subst_m[d.defs[0]] = def_loc.expr.args[0]
+                    continue
+
+        new_def = d.copy(subst_m)
+
+        for v in new_def.defs:
+            assert v not in definition  # Guaranteed by SSA
+            definition[v] = new_def
+
+        new_defs.append(new_def)
+
+    # Pass 2: Remove dead prim_from_bv
+    live = set(outputs)  # type: Set[Var]
+    for d in new_defs:
+        live = live.union(d.uses())
+
+    new_defs = [d for d in new_defs if not (d.expr.inst == prim_from_bv and
+                                            d.defs[0] not in live)]
+
+    return Rtl(*new_defs)

--- a/lib/cretonne/meta/semantics/elaborate.py
+++ b/lib/cretonne/meta/semantics/elaborate.py
@@ -6,10 +6,11 @@ primitive cretonne instructions, which map well to SMTLIB functions.
 from .primitives import GROUP as PRIMITIVES, prim_to_bv, prim_from_bv
 from cdsl.ti import ti_rtl, TypeEnv, get_type_env
 from cdsl.typevar import TypeVar
+from cdsl.xform import Rtl
 
 try:
     from typing import TYPE_CHECKING, Dict, Union, List, Set, Tuple # noqa
-    from cdsl.xform import Rtl, XForm # noqa
+    from cdsl.xform import XForm # noqa
     from cdsl.ast import Var, Def, VarMap # noqa
     from cdsl.ti import VarTyping # noqa
 except ImportError:

--- a/lib/cretonne/meta/semantics/primitives.py
+++ b/lib/cretonne/meta/semantics/primitives.py
@@ -1,0 +1,71 @@
+"""
+Cretonne primitive instruction set.
+
+This module defines a primitive instruction set, in terms of which the base set
+is described. Most instructions in this set correspond 1-1 with an SMTLIB
+bitvector function.
+"""
+from __future__ import absolute_import
+from cdsl.operands import Operand
+from cdsl.typevar import TypeVar
+from cdsl.instructions import Instruction, InstructionGroup
+from cdsl.ti import SameWidth
+import base.formats # noqa
+
+GROUP = InstructionGroup("primitive", "Primitive instruction set")
+
+BV = TypeVar('BV', 'A bitvector type.', bitvecs=True)
+Real = TypeVar('Real', 'Any real type.', ints=True, floats=True,
+               bools=True, simd=True)
+
+x = Operand('x', BV, doc="A semantic value X")
+y = Operand('x', BV, doc="A semantic value Y (same width as X)")
+a = Operand('a', BV, doc="A semantic value A (same width as X)")
+
+real = Operand('real', Real, doc="A real cretonne value")
+fromReal = Operand('fromReal', Real.to_bitvec(),
+                   doc="A real cretonne value converted to a BV")
+
+prim_to_bv = Instruction(
+        'prim_to_bv', r"""
+        Convert an SSA Value to a flat bitvector
+        """,
+        ins=(real), outs=(fromReal))
+
+# Note that when converting from BV->real values, we use a constraint and not a
+# derived function. This reflects that fact that to_bitvec() is not a
+# bijection.
+prim_from_bv = Instruction(
+        'prim_from_bv', r"""
+        Convert a flat bitvector to a real SSA Value.
+        """,
+        ins=(x), outs=(real),
+        constraints=SameWidth(BV, Real))
+
+xh = Operand('xh', BV.half_width(),
+             doc="A semantic value representing the upper half of X")
+xl = Operand('xl', BV.half_width(),
+             doc="A semantic value representing the lower half of X")
+bvsplit = Instruction(
+        'bvsplit', r"""
+        """,
+        ins=(x), outs=(xh, xl))
+
+xy = Operand('xy', BV.double_width(),
+             doc="A semantic value representing the concatenation of X and Y")
+bvconcat = Instruction(
+        'bvconcat', r"""
+        """,
+        ins=(x, y), outs=xy)
+
+bvadd = Instruction(
+        'bvadd', r"""
+        Standard 2's complement addition. Equivalent to wrapping integer
+        addition: :math:`a := x + y \pmod{2^B}`.
+
+        This instruction does not depend on the signed/unsigned interpretation
+        of the operands.
+        """,
+        ins=(x, y), outs=a)
+
+GROUP.close()

--- a/lib/cretonne/meta/semantics/test_elaborate.py
+++ b/lib/cretonne/meta/semantics/test_elaborate.py
@@ -232,16 +232,16 @@ class TestElaborate(TestCase):
     def test_elaborate_iadd_simple(self):
         # type: () -> None
         i32.by(2)  # Make sure i32x2 exists.
-        r = Rtl(
-                self.v0 << iadd.i32(self.v1, self.v2),
-        )
-        sem = elaborate(cleanup_concrete_rtl(r))
         x = Var('x')
         y = Var('y')
         a = Var('a')
         bvx = Var('bvx')
         bvy = Var('bvy')
         bva = Var('bva')
+        r = Rtl(
+                a << iadd.i32(x, y),
+        )
+        sem = elaborate(cleanup_concrete_rtl(r))
 
         assert concrete_rtls_eq(sem, cleanup_concrete_rtl(Rtl(
             bvx << prim_to_bv.i32(x),

--- a/lib/cretonne/meta/semantics/test_elaborate.py
+++ b/lib/cretonne/meta/semantics/test_elaborate.py
@@ -1,0 +1,337 @@
+from __future__ import absolute_import
+from base.instructions import vselect, vsplit, vconcat, iconst, iadd, bint
+from base.instructions import b1, icmp, ireduce
+from base.immediates import intcc
+from base.types import i64, i8, b32, i32, i16, f32
+from cdsl.typevar import TypeVar
+from cdsl.ast import Var
+from cdsl.xform import Rtl
+from unittest import TestCase
+from .elaborate import cleanup_concrete_rtl, elaborate, is_rtl_concrete,\
+    cleanup_semantics
+from .primitives import prim_to_bv, bvsplit, prim_from_bv, bvconcat, bvadd
+import base.semantics  # noqa
+
+
+def concrete_rtls_eq(r1, r2):
+    # type: (Rtl, Rtl) -> bool
+    """
+    Check whether 2 concrete Rtls are equivalent. That is:
+        1) They are structurally the same (i.e. there is a substitution between
+        them)
+        2) Corresponding Vars between them have the same singleton type.
+    """
+    assert is_rtl_concrete(r1)
+    assert is_rtl_concrete(r2)
+
+    s = r1.substitution(r2, {})
+
+    if s is None:
+        return False
+
+    for (v, v1) in s.items():
+        if v.get_typevar().singleton_type() !=\
+           v1.get_typevar().singleton_type():
+            return False
+
+    return True
+
+
+class TestCleanupConcreteRtl(TestCase):
+    """
+    Test cleanup_concrete_rtl(). cleanup_concrete_rtl() should take Rtls for
+    which we can infer a single concrete typing, and update the TypeVars
+    in-place to singleton TVs.
+    """
+    def test_cleanup_concrete_rtl(self):
+        # type: () -> None
+        typ = i64.by(4)
+        x = Var('x')
+        lo = Var('lo')
+        hi = Var('hi')
+
+        x.set_typevar(TypeVar.singleton(typ))
+        r = Rtl(
+                (lo, hi) << vsplit(x),
+        )
+        r1 = cleanup_concrete_rtl(r)
+
+        s = r.substitution(r1, {})
+        assert s is not None
+        assert s[x].get_typevar().singleton_type() == typ
+        assert s[lo].get_typevar().singleton_type() == i64.by(2)
+        assert s[hi].get_typevar().singleton_type() == i64.by(2)
+
+    def test_cleanup_concrete_rtl_fail(self):
+        # type: () -> None
+        x = Var('x')
+        lo = Var('lo')
+        hi = Var('hi')
+        r = Rtl(
+                (lo, hi) << vsplit(x),
+        )
+
+        with self.assertRaises(AssertionError):
+            cleanup_concrete_rtl(r)
+
+    def test_cleanup_concrete_rtl_ireduce(self):
+        # type: () -> None
+        x = Var('x')
+        y = Var('y')
+        x.set_typevar(TypeVar.singleton(i8.by(2)))
+        r = Rtl(
+                y << ireduce(x),
+        )
+
+        r1 = cleanup_concrete_rtl(r)
+
+        s = r.substitution(r1, {})
+        assert s is not None
+        assert s[x].get_typevar().singleton_type() == i8.by(2)
+        assert s[y].get_typevar().singleton_type() == i8.by(2)
+
+    def test_cleanup_concrete_rtl_ireduce_bad(self):
+        # type: () -> None
+        x = Var('x')
+        y = Var('y')
+        x.set_typevar(TypeVar.singleton(i16.by(1)))
+        r = Rtl(
+                y << ireduce(x),
+        )
+
+        with self.assertRaises(AssertionError):
+            cleanup_concrete_rtl(r)
+
+    def test_vselect_icmpimm(self):
+        # type: () -> None
+        x = Var('x')
+        y = Var('y')
+        z = Var('z')
+        w = Var('w')
+        v = Var('v')
+        zeroes = Var('zeroes')
+        imm0 = Var("imm0")
+
+        zeroes.set_typevar(TypeVar.singleton(i32.by(4)))
+        z.set_typevar(TypeVar.singleton(f32.by(4)))
+
+        r = Rtl(
+                zeroes << iconst(imm0),
+                y << icmp(intcc.eq, x, zeroes),
+                v << vselect(y, z, w),
+        )
+
+        r1 = cleanup_concrete_rtl(r)
+
+        s = r.substitution(r1, {})
+        assert s is not None
+        assert s[zeroes].get_typevar().singleton_type() == i32.by(4)
+        assert s[x].get_typevar().singleton_type() == i32.by(4)
+        assert s[y].get_typevar().singleton_type() == b32.by(4)
+        assert s[z].get_typevar().singleton_type() == f32.by(4)
+        assert s[w].get_typevar().singleton_type() == f32.by(4)
+        assert s[v].get_typevar().singleton_type() == f32.by(4)
+
+    def test_bint(self):
+        # type: () -> None
+        x = Var('x')
+        y = Var('y')
+        z = Var('z')
+        w = Var('w')
+        v = Var('v')
+        u = Var('u')
+
+        x.set_typevar(TypeVar.singleton(i32.by(8)))
+        z.set_typevar(TypeVar.singleton(i32.by(8)))
+        # TODO: Relax this to simd=True
+        v.set_typevar(TypeVar('v', '', bools=(1, 1), simd=(8, 8)))
+
+        r = Rtl(
+            z << iadd(x, y),
+            w << bint(v),
+            u << iadd(z, w)
+        )
+
+        r1 = cleanup_concrete_rtl(r)
+
+        s = r.substitution(r1, {})
+        assert s is not None
+        assert s[x].get_typevar().singleton_type() == i32.by(8)
+        assert s[y].get_typevar().singleton_type() == i32.by(8)
+        assert s[z].get_typevar().singleton_type() == i32.by(8)
+        assert s[w].get_typevar().singleton_type() == i32.by(8)
+        assert s[u].get_typevar().singleton_type() == i32.by(8)
+        assert s[v].get_typevar().singleton_type() == b1.by(8)
+
+
+class TestElaborate(TestCase):
+    """
+    Test semantics elaboration.
+    """
+    def setUp(self):
+        # type: () -> None
+        self.v0 = Var("v0")
+        self.v1 = Var("v1")
+        self.v2 = Var("v2")
+        self.v3 = Var("v3")
+        self.v4 = Var("v4")
+        self.v5 = Var("v5")
+        self.v6 = Var("v6")
+        self.v7 = Var("v7")
+        self.v8 = Var("v8")
+        self.v9 = Var("v9")
+        self.imm0 = Var("imm0")
+        self.IxN_nonscalar = TypeVar("IxN_nonscalar", "", ints=True,
+                                     scalars=False, simd=True)
+        self.TxN = TypeVar("TxN", "", ints=True, bools=True, floats=True,
+                           scalars=False, simd=True)
+        self.b1 = TypeVar.singleton(b1)
+
+    def test_elaborate_vsplit(self):
+        # type: () -> None
+        i32.by(4)  # Make sure i32x4 exists.
+        i32.by(2)  # Make sure i32x2 exists.
+        r = Rtl(
+                (self.v0, self.v1) << vsplit.i32x4(self.v2),
+        )
+        sem = elaborate(cleanup_concrete_rtl(r))
+        bvx = Var('bvx')
+        bvlo = Var('bvlo')
+        bvhi = Var('bvhi')
+        x = Var('x')
+        lo = Var('lo')
+        hi = Var('hi')
+
+        assert concrete_rtls_eq(sem, cleanup_concrete_rtl(Rtl(
+            bvx << prim_to_bv.i32x4(x),
+            (bvlo, bvhi) << bvsplit.bv128(bvx),
+            lo << prim_from_bv.i32x2.bv64(bvlo),
+            hi << prim_from_bv.i32x2.bv64(bvhi))))
+
+    def test_elaborate_vconcat(self):
+        # type: () -> None
+        i32.by(4)  # Make sure i32x4 exists.
+        i32.by(2)  # Make sure i32x2 exists.
+        r = Rtl(
+                self.v0 << vconcat.i32x2(self.v1, self.v2),
+        )
+        sem = elaborate(cleanup_concrete_rtl(r))
+        bvx = Var('bvx')
+        bvlo = Var('bvlo')
+        bvhi = Var('bvhi')
+        x = Var('x')
+        lo = Var('lo')
+        hi = Var('hi')
+
+        assert concrete_rtls_eq(sem, cleanup_concrete_rtl(Rtl(
+            bvlo << prim_to_bv.i32x2(lo),
+            bvhi << prim_to_bv.i32x2(hi),
+            bvx << bvconcat.bv64(bvlo, bvhi),
+            x << prim_from_bv.i32x4.bv128(bvx))))
+
+    def test_elaborate_iadd_simple(self):
+        # type: () -> None
+        i32.by(2)  # Make sure i32x2 exists.
+        r = Rtl(
+                self.v0 << iadd.i32(self.v1, self.v2),
+        )
+        sem = elaborate(cleanup_concrete_rtl(r))
+        x = Var('x')
+        y = Var('y')
+        a = Var('a')
+        bvx = Var('bvx')
+        bvy = Var('bvy')
+        bva = Var('bva')
+
+        assert concrete_rtls_eq(sem, cleanup_concrete_rtl(Rtl(
+            bvx << prim_to_bv.i32(x),
+            bvy << prim_to_bv.i32(y),
+            bva << bvadd.bv32(bvx, bvy),
+            a << prim_from_bv.i32.bv32(bva))))
+
+    def test_elaborate_iadd_elaborate_1(self):
+        # type: () -> None
+        i32.by(2)  # Make sure i32x2 exists.
+        r = Rtl(
+                self.v0 << iadd.i32x2(self.v1, self.v2),
+        )
+        sem = cleanup_semantics(elaborate(cleanup_concrete_rtl(r)),
+                                set([self.v0]))
+        x = Var('x')
+        y = Var('y')
+        a = Var('a')
+        bvx_1 = Var('bvx_1')
+        bvx_2 = Var('bvx_2')
+        bvx_5 = Var('bvx_5')
+        bvlo_1 = Var('bvlo_1')
+        bvlo_2 = Var('bvlo_2')
+        bvhi_1 = Var('bvhi_1')
+        bvhi_2 = Var('bvhi_2')
+
+        bva_3 = Var('bva_3')
+        bva_4 = Var('bva_4')
+
+        assert concrete_rtls_eq(sem, cleanup_concrete_rtl(Rtl(
+            bvx_1 << prim_to_bv.i32x2(x),
+            (bvlo_1, bvhi_1) << bvsplit.bv64(bvx_1),
+            bvx_2 << prim_to_bv.i32x2(y),
+            (bvlo_2, bvhi_2) << bvsplit.bv64(bvx_2),
+            bva_3 << bvadd.bv32(bvlo_1, bvlo_2),
+            bva_4 << bvadd.bv32(bvhi_1, bvhi_2),
+            bvx_5 << bvconcat.bv32(bva_3, bva_4),
+            a << prim_from_bv.i32x2.bv64(bvx_5))))
+
+    def test_elaborate_iadd_elaborate_2(self):
+        # type: () -> None
+        i8.by(4)  # Make sure i32x2 exists.
+        r = Rtl(
+                self.v0 << iadd.i8x4(self.v1, self.v2),
+        )
+
+        sem = cleanup_semantics(elaborate(cleanup_concrete_rtl(r)),
+                                set([self.v0]))
+        x = Var('x')
+        y = Var('y')
+        a = Var('a')
+        bvx_1 = Var('bvx_1')
+        bvx_2 = Var('bvx_2')
+        bvx_5 = Var('bvx_5')
+        bvx_10 = Var('bvx_10')
+        bvx_15 = Var('bvx_15')
+
+        bvlo_1 = Var('bvlo_1')
+        bvlo_2 = Var('bvlo_2')
+        bvlo_6 = Var('bvlo_6')
+        bvlo_7 = Var('bvlo_7')
+        bvlo_11 = Var('bvlo_11')
+        bvlo_12 = Var('bvlo_12')
+
+        bvhi_1 = Var('bvhi_1')
+        bvhi_2 = Var('bvhi_2')
+        bvhi_6 = Var('bvhi_6')
+        bvhi_7 = Var('bvhi_7')
+        bvhi_11 = Var('bvhi_11')
+        bvhi_12 = Var('bvhi_12')
+
+        bva_8 = Var('bva_8')
+        bva_9 = Var('bva_9')
+        bva_13 = Var('bva_13')
+        bva_14 = Var('bva_14')
+
+        assert concrete_rtls_eq(sem, cleanup_concrete_rtl(Rtl(
+            bvx_1 << prim_to_bv.i8x4(x),
+            (bvlo_1, bvhi_1) << bvsplit.bv32(bvx_1),
+            bvx_2 << prim_to_bv.i8x4(y),
+            (bvlo_2, bvhi_2) << bvsplit.bv32(bvx_2),
+            (bvlo_6, bvhi_6) << bvsplit.bv16(bvlo_1),
+            (bvlo_7, bvhi_7) << bvsplit.bv16(bvlo_2),
+            bva_8 << bvadd.bv8(bvlo_6, bvlo_7),
+            bva_9 << bvadd.bv8(bvhi_6, bvhi_7),
+            bvx_10 << bvconcat.bv8(bva_8, bva_9),
+            (bvlo_11, bvhi_11) << bvsplit.bv16(bvhi_1),
+            (bvlo_12, bvhi_12) << bvsplit.bv16(bvhi_2),
+            bva_13 << bvadd.bv8(bvlo_11, bvlo_12),
+            bva_14 << bvadd.bv8(bvhi_11, bvhi_12),
+            bvx_15 << bvconcat.bv8(bva_13, bva_14),
+            bvx_5 << bvconcat.bv16(bvx_10, bvx_15),
+            a << prim_from_bv.i8x4.bv32(bvx_5))))

--- a/lib/cretonne/meta/semantics/types.py
+++ b/lib/cretonne/meta/semantics/types.py
@@ -1,0 +1,9 @@
+"""
+The semantics.types module predefines all the Cretone primitive bitvector
+types.
+"""
+from cdsl.types import BVType
+from cdsl.typevar import MAX_BITVEC, int_log2
+
+for width in range(0, int_log2(MAX_BITVEC)+1):
+    BVType(2**width)

--- a/lib/cretonne/meta/semantics/types.py
+++ b/lib/cretonne/meta/semantics/types.py
@@ -1,9 +1,0 @@
-"""
-The semantics.types module predefines all the Cretone primitive bitvector
-types.
-"""
-from cdsl.types import BVType
-from cdsl.typevar import MAX_BITVEC, int_log2
-
-for width in range(0, int_log2(MAX_BITVEC)+1):
-    BVType(2**width)


### PR DESCRIPTION
This PR includes the basic machinery to specify instruction semantics in terms of a sequence of XForms. In order of commits it includes:

1) Helper routines {Ast,Def,Rtl}.vars(), Def.{definitions(), uses{}), {Ast, Def,Rtl}.substitutions()

2) The new BVType and support for BVType in TypeVar/TypeSet. BVType represents a flat bitvector of the same size as a real cretonne type. Its non-emittable, and only used by primitive instructions to describe the semantics of larger instructions. It corresponds to a smtlib bitvector.

3) Instruction semantics. This includes:
        - semantics/primitives.py - a new InstructionGroup containing the 'primitive' set of instructions in terms of which we describe all other instructions. All of these should correspond almost 1-1 to bitvector functions in smtlib
        - semantics/elaborate.py - routines to repeatedly in-line non-primitive instructions in an Rtl until we've reached a semantically equivalent Rtl with all-primitive instructions
        - Instruction.semantics field, and sanity checking of semantics using verify_semantics()
        - base/semantics.py - sample semantics for enough instructions to describe iadd