### PR TITLE
Change TV ranking to select src vars as a representative during unification

### DIFF
--- a/lib/cretonne/meta/cdsl/test_ti.py
+++ b/lib/cretonne/meta/cdsl/test_ti.py
@@ -158,8 +158,7 @@ class TypeCheckingBaseTest(TestCase):
         self.v8 = Var("v8")
         self.v9 = Var("v9")
         self.imm0 = Var("imm0")
-        self.IxN_nonscalar = TypeVar("IxN_nonscalar", "", ints=True,
-                                     scalars=False, simd=True)
+        self.IxN = TypeVar("IxN", "", ints=True, scalars=True, simd=True)
         self.TxN = TypeVar("TxN", "", ints=True, bools=True, floats=True,
                            scalars=False, simd=True)
         self.b1 = TypeVar.singleton(b1)
@@ -176,7 +175,7 @@ class TestRTL(TypeCheckingBaseTest):
         self.assertEqual(ti_rtl(r, ti),
                          "On line 1: fail ti on `typeof_v2` <: `1`: " +
                          "Error: empty type created when unifying " +
-                         "`typeof_v2` and `half_vector(typeof_v2)`")
+                         "`typeof_v3` and `half_vector(typeof_v3)`")
 
     def test_vselect(self):
         # type: () -> None
@@ -202,11 +201,11 @@ class TestRTL(TypeCheckingBaseTest):
         )
         ti = TypeEnv()
         typing = ti_rtl(r, ti)
-        ixn = self.IxN_nonscalar.get_fresh_copy("IxN1")
+        ixn = self.IxN.get_fresh_copy("IxN1")
         txn = self.TxN.get_fresh_copy("TxN1")
         check_typing(typing, ({
             self.v0: ixn,
-            self.v1: ixn.as_bool(),
+            self.v1: txn.as_bool(),
             self.v2: ixn,
             self.v3: txn,
             self.v4: txn,
@@ -319,7 +318,7 @@ class TestRTL(TypeCheckingBaseTest):
         self.assertEqual(typing,
                          "On line 2: fail ti on `typeof_v4` <: `4`: " +
                          "Error: empty type created when unifying " +
-                         "`typeof_v4` and `typeof_v5`")
+                         "`i16` and `i32`")
 
     def test_extend_reduce(self):
         # type: () -> None
@@ -471,7 +470,7 @@ class TestXForm(TypeCheckingBaseTest):
             assert var_m[v0] == var_m[v2] and \
                    var_m[v3] == var_m[v4] and\
                    var_m[v5] == var_m[v3] and\
-                   var_m[v1] == var_m[v2].as_bool() and\
+                   var_m[v1] == var_m[v5].as_bool() and\
                    var_m[v1].get_typeset() == var_m[v3].as_bool().get_typeset()
             check_concrete_typing_xform(var_m, xform)
 

--- a/lib/cretonne/meta/semantics/__init__.py
+++ b/lib/cretonne/meta/semantics/__init__.py
@@ -31,6 +31,7 @@ def verify_semantics(inst, src, xforms):
 
     # 2) Any possible typing for the instruction should be covered by
     #    exactly ONE semantic XForm
+    src = src.copy({})
     typenv = get_type_env(ti_rtl(src, TypeEnv()))
     typenv.normalize()
     typenv = typenv.extract()

--- a/lib/cretonne/meta/semantics/primitives.py
+++ b/lib/cretonne/meta/semantics/primitives.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import
 from cdsl.operands import Operand
 from cdsl.typevar import TypeVar
 from cdsl.instructions import Instruction, InstructionGroup
-from cdsl.ti import SameWidth
 import base.formats # noqa
 
 GROUP = InstructionGroup("primitive", "Primitive instruction set")
@@ -39,8 +38,7 @@ prim_from_bv = Instruction(
         'prim_from_bv', r"""
         Convert a flat bitvector to a real SSA Value.
         """,
-        ins=(x), outs=(real),
-        constraints=SameWidth(BV, Real))
+        ins=(fromReal), outs=(real))
 
 xh = Operand('xh', BV.half_width(),
              doc="A semantic value representing the upper half of X")

--- a/lib/cretonne/meta/semantics/test_elaborate.py
+++ b/lib/cretonne/meta/semantics/test_elaborate.py
@@ -205,8 +205,8 @@ class TestElaborate(TestCase):
         assert concrete_rtls_eq(sem, cleanup_concrete_rtl(Rtl(
             bvx << prim_to_bv.i32x4(x),
             (bvlo, bvhi) << bvsplit.bv128(bvx),
-            lo << prim_from_bv.i32x2.bv64(bvlo),
-            hi << prim_from_bv.i32x2.bv64(bvhi))))
+            lo << prim_from_bv.i32x2(bvlo),
+            hi << prim_from_bv.i32x2(bvhi))))
 
     def test_elaborate_vconcat(self):
         # type: () -> None
@@ -227,7 +227,7 @@ class TestElaborate(TestCase):
             bvlo << prim_to_bv.i32x2(lo),
             bvhi << prim_to_bv.i32x2(hi),
             bvx << bvconcat.bv64(bvlo, bvhi),
-            x << prim_from_bv.i32x4.bv128(bvx))))
+            x << prim_from_bv.i32x4(bvx))))
 
     def test_elaborate_iadd_simple(self):
         # type: () -> None
@@ -247,7 +247,7 @@ class TestElaborate(TestCase):
             bvx << prim_to_bv.i32(x),
             bvy << prim_to_bv.i32(y),
             bva << bvadd.bv32(bvx, bvy),
-            a << prim_from_bv.i32.bv32(bva))))
+            a << prim_from_bv.i32(bva))))
 
     def test_elaborate_iadd_elaborate_1(self):
         # type: () -> None
@@ -279,7 +279,7 @@ class TestElaborate(TestCase):
             bva_3 << bvadd.bv32(bvlo_1, bvlo_2),
             bva_4 << bvadd.bv32(bvhi_1, bvhi_2),
             bvx_5 << bvconcat.bv32(bva_3, bva_4),
-            a << prim_from_bv.i32x2.bv64(bvx_5))))
+            a << prim_from_bv.i32x2(bvx_5))))
 
     def test_elaborate_iadd_elaborate_2(self):
         # type: () -> None
@@ -334,4 +334,4 @@ class TestElaborate(TestCase):
             bva_14 << bvadd.bv8(bvhi_11, bvhi_12),
             bvx_15 << bvconcat.bv8(bva_13, bva_14),
             bvx_5 << bvconcat.bv16(bvx_10, bvx_15),
-            a << prim_from_bv.i8x4.bv32(bvx_5))))
+            a << prim_from_bv.i8x4(bvx_5))))

--- a/lib/cretonne/meta/test_gen_legalizer.py
+++ b/lib/cretonne/meta/test_gen_legalizer.py
@@ -153,8 +153,7 @@ class TestRuntimeChecks(TestCase):
 
     def test_vselect_imm(self):
         # type: () -> None
-        ts = TypeSet(lanes=(2, 256), ints=(8, 64),
-                     floats=(32, 64), bools=(8, 64))
+        ts = TypeSet(lanes=(2, 256), ints=(8, 64))
         r = Rtl(
                 self.v0 << iconst(self.imm0),
                 self.v1 << icmp(intcc.eq, self.v2, self.v0),
@@ -167,7 +166,7 @@ class TestRuntimeChecks(TestCase):
             .format(self.v3.get_typevar().name)
 
         self.check_yo_check(
-            x, sequence(typeset_check(self.v3, ts),
+            x, sequence(typeset_check(self.v2, ts),
                         equiv_check(tv2_exp, tv3_exp)))
 
     def test_reduce_extend(self):


### PR DESCRIPTION
When unifying 2 type variables(tvs), type inference (ti) uses a heuristic partial ordering over tvs to select which is the representative. Currently derived tvs are selected over non-derived tvs in an effort to
reduce the number of free tvs. Unfortunately, this sometimes results in inferred types for XForms that express tvs in source as functions of tvs in dst. This violates a basic constraint of XForms. This was observed in the following example:

```
XForm(Rtl(x << iconst(y)),
      Rtl(x1 << iconst(y),
          x2 << iconst(y),
          x << vconcat (x1, x2)))
```

The current ti code took T_x1 as a free tv and inferred the type of x as T_x1.double_vector(), instead of picking T_x as a free typevar and inferring the type of x1/x2 as T_x.half_vector().

In this PR we change the way we compute the partial ordering of TVs to select a representative when doing union based on whether the underlying free variable appears in the src rtl or not.

Additionally there are 3 small cleanups:
       - make the signature of prim_from_bv simpler by removing the constraint
       - fix small bug in verify_semantics()
       - small bug in TypeEnv.dot()