### PR TITLE
Add more semantics and utilities to emit smtlib queries

### DIFF
--- a/lib/cretonne/meta/base/instructions.py
+++ b/lib/cretonne/meta/base/instructions.py
@@ -1382,7 +1382,7 @@ breduce = Instruction(
         The result type must have the same number of vector lanes as the input,
         and each lane must not have more bits that the input lanes. If the
         input and output types are the same, this is a no-op.
-        """, ins=x, outs=a)
+        """, ins=x, outs=a, constraints=WiderOrEq(Bool, BoolTo))
 
 BoolTo = TypeVar(
         'BoolTo',
@@ -1399,7 +1399,7 @@ bextend = Instruction(
         The result type must have the same number of vector lanes as the input,
         and each lane must not have fewer bits that the input lanes. If the
         input and output types are the same, this is a no-op.
-        """, ins=x, outs=a)
+        """, ins=x, outs=a, constraints=WiderOrEq(BoolTo, Bool))
 
 IntTo = TypeVar(
         'IntTo', 'An integer type with the same number of lanes',

--- a/lib/cretonne/meta/base/semantics.py
+++ b/lib/cretonne/meta/base/semantics.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 from semantics.primitives import prim_to_bv, prim_from_bv, bvsplit, bvconcat,\
     bvadd, bvult, bvzeroext
-from .instructions import vsplit, vconcat, iadd, iadd_cout, icmp, bextend
+from .instructions import vsplit, vconcat, iadd, iadd_cout, icmp, bextend, \
+    isplit, iconcat, iadd_cin, iadd_carry
 from .immediates import intcc
 from cdsl.xform import Rtl
 from cdsl.ast import Var
@@ -13,18 +14,24 @@ y = Var('y')
 a = Var('a')
 b = Var('b')
 c_out = Var('c_out')
+c_in = Var('c_in')
 bvc_out = Var('bvc_out')
+bvc_in = Var('bvc_in')
 xhi = Var('xhi')
 yhi = Var('yhi')
 ahi = Var('ahi')
+bhi = Var('bhi')
 xlo = Var('xlo')
 ylo = Var('ylo')
 alo = Var('alo')
+blo = Var('blo')
 lo = Var('lo')
 hi = Var('hi')
 bvx = Var('bvx')
 bvy = Var('bvy')
 bva = Var('bva')
+bvt = Var('bvt')
+bvs = Var('bvs')
 bva_wide = Var('bva_wide')
 bvlo = Var('bvlo')
 bvhi = Var('bvhi')
@@ -51,16 +58,34 @@ vconcat.set_semantics(
 
 iadd.set_semantics(
     a << iadd(x, y),
-    (Rtl(bvx << prim_to_bv(x),
-         bvy << prim_to_bv(y),
-         bva << bvadd(bvx, bvy),
-         a << prim_from_bv(bva)),
-     [InTypeset(x.get_typevar(), ScalarTS)]),
-    Rtl((xlo, xhi) << vsplit(x),
+    (Rtl(
+        bvx << prim_to_bv(x),
+        bvy << prim_to_bv(y),
+        bva << bvadd(bvx, bvy),
+        a << prim_from_bv(bva)
+    ), [InTypeset(x.get_typevar(), ScalarTS)]),
+    Rtl(
+        (xlo, xhi) << vsplit(x),
         (ylo, yhi) << vsplit(y),
         alo << iadd(xlo, ylo),
         ahi << iadd(xhi, yhi),
-        a << vconcat(alo, ahi)))
+        a << vconcat(alo, ahi)
+    ))
+
+#
+# Integer arithmetic with carry and/or borrow.
+#
+iadd_cin.set_semantics(
+    a << iadd_cin(x, y, c_in),
+    Rtl(
+        bvx << prim_to_bv(x),
+        bvy << prim_to_bv(y),
+        bvc_in << prim_to_bv(c_in),
+        bvs << bvzeroext(bvc_in),
+        bvt << bvadd(bvx, bvy),
+        bva << bvadd(bvt, bvs),
+        a << prim_from_bv(bva)
+    ))
 
 iadd_cout.set_semantics(
     (a, c_out) << iadd_cout(x, y),
@@ -73,6 +98,20 @@ iadd_cout.set_semantics(
         c_out << prim_from_bv(bvc_out)
     ))
 
+iadd_carry.set_semantics(
+    (a, c_out) << iadd_carry(x, y, c_in),
+    Rtl(
+        bvx << prim_to_bv(x),
+        bvy << prim_to_bv(y),
+        bvc_in << prim_to_bv(c_in),
+        bvs << bvzeroext(bvc_in),
+        bvt << bvadd(bvx, bvy),
+        bva << bvadd(bvt, bvs),
+        bvc_out << bvult(bva, bvx),
+        a << prim_from_bv(bva),
+        c_out << prim_from_bv(bvc_out)
+    ))
+
 bextend.set_semantics(
     a << bextend(x),
     (Rtl(
@@ -80,10 +119,12 @@ bextend.set_semantics(
         bvy << bvzeroext(bvx),
         a << prim_from_bv(bvy)
     ), [InTypeset(x.get_typevar(), ScalarTS)]),
-    Rtl((xlo, xhi) << vsplit(x),
+    Rtl(
+        (xlo, xhi) << vsplit(x),
         alo << bextend(xlo),
         ahi << bextend(xhi),
-        a << vconcat(alo, ahi)))
+        a << vconcat(alo, ahi)
+    ))
 
 icmp.set_semantics(
     a << icmp(intcc.ult, x, y),
@@ -94,9 +135,47 @@ icmp.set_semantics(
         bva_wide << bvzeroext(bva),
         a << prim_from_bv(bva_wide),
     ), [InTypeset(x.get_typevar(), ScalarTS)]),
-    Rtl((xlo, xhi) << vsplit(x),
+    Rtl(
+        (xlo, xhi) << vsplit(x),
         (ylo, yhi) << vsplit(y),
         alo << icmp(intcc.ult, xlo, ylo),
         ahi << icmp(intcc.ult, xhi, yhi),
         b << vconcat(alo, ahi),
-        a << bextend(b)))
+        a << bextend(b)
+    ))
+
+#
+# Legalization helper instructions.
+#
+
+isplit.set_semantics(
+    (xlo, xhi) << isplit(x),
+    (Rtl(
+        bvx << prim_to_bv(x),
+        (bvlo, bvhi) << bvsplit(bvx),
+        xlo << prim_from_bv(bvlo),
+        xhi << prim_from_bv(bvhi)
+    ), [InTypeset(x.get_typevar(), ScalarTS)]),
+    Rtl(
+        (a, b) << vsplit(x),
+        (alo, ahi) << isplit(a),
+        (blo, bhi) << isplit(b),
+        xlo << vconcat(alo, blo),
+        xhi << vconcat(bhi, bhi)
+    ))
+
+iconcat.set_semantics(
+    x << iconcat(xlo, xhi),
+    (Rtl(
+        bvlo << prim_to_bv(xlo),
+        bvhi << prim_to_bv(xhi),
+        bvx << bvconcat(bvlo, bvhi),
+        x << prim_from_bv(bvx)
+    ), [InTypeset(x.get_typevar(), ScalarTS)]),
+    Rtl(
+        (alo, ahi) << vsplit(xlo),
+        (blo, bhi) << vsplit(xhi),
+        a << iconcat(alo, blo),
+        b << iconcat(ahi, bhi),
+        x << vconcat(a, b),
+    ))

--- a/lib/cretonne/meta/base/semantics.py
+++ b/lib/cretonne/meta/base/semantics.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 from semantics.primitives import prim_to_bv, prim_from_bv, bvsplit, bvconcat,\
-    bvadd
-from .instructions import vsplit, vconcat, iadd
+    bvadd, bvult, bvzeroext
+from .instructions import vsplit, vconcat, iadd, iadd_cout, icmp, bextend
+from .immediates import intcc
 from cdsl.xform import Rtl
 from cdsl.ast import Var
 from cdsl.typevar import TypeSet
@@ -10,6 +11,9 @@ from cdsl.ti import InTypeset
 x = Var('x')
 y = Var('y')
 a = Var('a')
+b = Var('b')
+c_out = Var('c_out')
+bvc_out = Var('bvc_out')
 xhi = Var('xhi')
 yhi = Var('yhi')
 ahi = Var('ahi')
@@ -21,6 +25,7 @@ hi = Var('hi')
 bvx = Var('bvx')
 bvy = Var('bvy')
 bva = Var('bva')
+bva_wide = Var('bva_wide')
 bvlo = Var('bvlo')
 bvhi = Var('bvhi')
 
@@ -56,3 +61,42 @@ iadd.set_semantics(
         alo << iadd(xlo, ylo),
         ahi << iadd(xhi, yhi),
         a << vconcat(alo, ahi)))
+
+iadd_cout.set_semantics(
+    (a, c_out) << iadd_cout(x, y),
+    Rtl(
+        bvx << prim_to_bv(x),
+        bvy << prim_to_bv(y),
+        bva << bvadd(bvx, bvy),
+        bvc_out << bvult(bva, bvx),
+        a << prim_from_bv(bva),
+        c_out << prim_from_bv(bvc_out)
+    ))
+
+bextend.set_semantics(
+    a << bextend(x),
+    (Rtl(
+        bvx << prim_to_bv(x),
+        bvy << bvzeroext(bvx),
+        a << prim_from_bv(bvy)
+    ), [InTypeset(x.get_typevar(), ScalarTS)]),
+    Rtl((xlo, xhi) << vsplit(x),
+        alo << bextend(xlo),
+        ahi << bextend(xhi),
+        a << vconcat(alo, ahi)))
+
+icmp.set_semantics(
+    a << icmp(intcc.ult, x, y),
+    (Rtl(
+        bvx << prim_to_bv(x),
+        bvy << prim_to_bv(y),
+        bva << bvult(bvx, bvy),
+        bva_wide << bvzeroext(bva),
+        a << prim_from_bv(bva_wide),
+    ), [InTypeset(x.get_typevar(), ScalarTS)]),
+    Rtl((xlo, xhi) << vsplit(x),
+        (ylo, yhi) << vsplit(y),
+        alo << icmp(intcc.ult, xlo, ylo),
+        ahi << icmp(intcc.ult, xhi, yhi),
+        b << vconcat(alo, ahi),
+        a << bextend(b)))

--- a/lib/cretonne/meta/cdsl/ast.py
+++ b/lib/cretonne/meta/cdsl/ast.py
@@ -156,19 +156,19 @@ class Var(Expr):
         Values that are defined only in the destination pattern.
     """
 
-    def __init__(self, name):
-        # type: (str) -> None
+    def __init__(self, name, typevar=None):
+        # type: (str, TypeVar) -> None
         self.name = name
         # The `Def` defining this variable in a source pattern.
         self.src_def = None  # type: Def
         # The `Def` defining this variable in a destination pattern.
         self.dst_def = None  # type: Def
         # TypeVar representing the type of this variable.
-        self.typevar = None  # type: TypeVar
+        self.typevar = typevar  # type: TypeVar
         # The original 'typeof(x)' type variable that was created for this Var.
         # This one doesn't change. `self.typevar` above may be changed to
         # another typevar by type inference.
-        self.original_typevar = None  # type: TypeVar
+        self.original_typevar = self.typevar  # type: TypeVar
 
     def __str__(self):
         # type: () -> str

--- a/lib/cretonne/meta/cdsl/test_ti.py
+++ b/lib/cretonne/meta/cdsl/test_ti.py
@@ -158,7 +158,8 @@ class TypeCheckingBaseTest(TestCase):
         self.v8 = Var("v8")
         self.v9 = Var("v9")
         self.imm0 = Var("imm0")
-        self.IxN = TypeVar("IxN", "", ints=True, scalars=True, simd=True)
+        self.IxN_nonscalar = TypeVar("IxN", "", ints=True, scalars=False,
+                                     simd=True)
         self.TxN = TypeVar("TxN", "", ints=True, bools=True, floats=True,
                            scalars=False, simd=True)
         self.b1 = TypeVar.singleton(b1)
@@ -175,7 +176,7 @@ class TestRTL(TypeCheckingBaseTest):
         self.assertEqual(ti_rtl(r, ti),
                          "On line 1: fail ti on `typeof_v2` <: `1`: " +
                          "Error: empty type created when unifying " +
-                         "`typeof_v3` and `half_vector(typeof_v3)`")
+                         "`typeof_v2` and `half_vector(typeof_v2)`")
 
     def test_vselect(self):
         # type: () -> None
@@ -201,11 +202,11 @@ class TestRTL(TypeCheckingBaseTest):
         )
         ti = TypeEnv()
         typing = ti_rtl(r, ti)
-        ixn = self.IxN.get_fresh_copy("IxN1")
+        ixn = self.IxN_nonscalar.get_fresh_copy("IxN1")
         txn = self.TxN.get_fresh_copy("TxN1")
         check_typing(typing, ({
             self.v0: ixn,
-            self.v1: txn.as_bool(),
+            self.v1: ixn.as_bool(),
             self.v2: ixn,
             self.v3: txn,
             self.v4: txn,
@@ -470,7 +471,7 @@ class TestXForm(TypeCheckingBaseTest):
             assert var_m[v0] == var_m[v2] and \
                    var_m[v3] == var_m[v4] and\
                    var_m[v5] == var_m[v3] and\
-                   var_m[v1] == var_m[v5].as_bool() and\
+                   var_m[v1] == var_m[v2].as_bool() and\
                    var_m[v1].get_typeset() == var_m[v3].as_bool().get_typeset()
             check_concrete_typing_xform(var_m, xform)
 

--- a/lib/cretonne/meta/cdsl/xform.py
+++ b/lib/cretonne/meta/cdsl/xform.py
@@ -67,6 +67,17 @@ class Rtl(object):
                       [d.definitions() for d in self.rtl],
                       set([]))
 
+    def free_vars(self):
+        # type: () -> Set[Var]
+        """ Return the set of free Vars used in self"""
+        def flow_f(s, d):
+            # type: (Set[Var], Def):    Set[Var]
+            """Compute the change in the set of free vars across a Def"""
+            s = s.difference(set(d.defs))
+            return s.union(set(a for a in d.expr.args if isinstance(a, Var)))
+
+        return reduce(flow_f, reversed(self.rtl), set([]))
+
     def substitution(self, other, s):
         # type: (Rtl, VarMap) -> Optional[VarMap]
         """

--- a/lib/cretonne/meta/cdsl/xform.py
+++ b/lib/cretonne/meta/cdsl/xform.py
@@ -5,13 +5,13 @@ from __future__ import absolute_import
 from .ast import Def, Var, Apply
 from .ti import ti_xform, TypeEnv, get_type_env
 from functools import reduce
+from .typevar import TypeVar
 
 try:
     from typing import Union, Iterator, Sequence, Iterable, List, Dict  # noqa
     from typing import Optional, Set # noqa
     from .ast import Expr, VarMap  # noqa
     from .ti import TypeConstraint  # noqa
-    from .typevar import TypeVar  # noqa
     DefApply = Union[Def, Apply]
 except ImportError:
     pass
@@ -84,6 +84,37 @@ class Rtl(object):
                 return None
 
         return s
+
+    def is_concrete(self):
+        # type: (Rtl) -> bool
+        """Return True iff every Var in the self has a singleton type."""
+        return all(v.get_typevar().singleton_type() is not None
+                   for v in self.vars())
+
+    def cleanup_concrete_rtl(self):
+        # type: (Rtl) -> None
+        """
+        Given that there is only 1 possible concrete typing T for self, assign
+        a singleton TV with the single type t=T[v] for each Var v \in self.
+        Its an error to call this on an Rtl with more than 1 possible typing.
+        """
+        from .ti import ti_rtl, TypeEnv
+        # 1) Infer the types of all vars in res
+        typenv = get_type_env(ti_rtl(self, TypeEnv()))
+        typenv.normalize()
+        typenv = typenv.extract()
+
+        # 2) Make sure there is only one possible type assignment
+        typings = list(typenv.concrete_typings())
+        assert len(typings) == 1
+        typing = typings[0]
+
+        # 3) Assign the only possible type to each variable.
+        for v in typenv.vars:
+            if v.get_typevar().singleton_type() is not None:
+                continue
+
+            v.set_typevar(TypeVar.singleton(typing[v].singleton_type()))
 
 
 class XForm(object):
@@ -277,6 +308,27 @@ class XForm(object):
             if not d.is_output():
                 raise AssertionError(
                         '{} not defined in dest pattern'.format(d))
+
+    def apply(self, r, suffix=None):
+        # type: (Rtl, str) -> Rtl
+        """
+        Given a concrete Rtl r s.t. r matches self.src, return the
+        corresponding concrete self.dst. If suffix is provided, any temporary
+        defs are renamed with '.suffix' appended to their old name.
+        """
+        assert r.is_concrete()
+        s = self.src.substitution(r, {})  # type: VarMap
+        assert s is not None
+
+        if (suffix is not None):
+            for v in self.dst.vars():
+                if v.is_temp():
+                    assert v not in s
+                    s[v] = Var(v.name + '.' + suffix)
+
+        dst = self.dst.copy(s)
+        dst.cleanup_concrete_rtl()
+        return dst
 
 
 class XFormGroup(object):

--- a/lib/cretonne/meta/cdsl/xform.py
+++ b/lib/cretonne/meta/cdsl/xform.py
@@ -5,13 +5,13 @@ from __future__ import absolute_import
 from .ast import Def, Var, Apply
 from .ti import ti_xform, TypeEnv, get_type_env
 from functools import reduce
-from .typevar import TypeVar
 
 try:
     from typing import Union, Iterator, Sequence, Iterable, List, Dict  # noqa
     from typing import Optional, Set # noqa
     from .ast import Expr, VarMap  # noqa
     from .ti import TypeConstraint  # noqa
+    from .typevar import TypeVar  # noqa
     DefApply = Union[Def, Apply]
 except ImportError:
     pass
@@ -69,12 +69,17 @@ class Rtl(object):
 
     def free_vars(self):
         # type: () -> Set[Var]
-        """ Return the set of free Vars used in self"""
+        """Return the set of free Vars corresp. to SSA vals used in self"""
         def flow_f(s, d):
             # type: (Set[Var], Def) -> Set[Var]
             """Compute the change in the set of free vars across a Def"""
             s = s.difference(set(d.defs))
-            return s.union(set(a for a in d.expr.args if isinstance(a, Var)))
+            uses = set(d.expr.args[i] for i in d.expr.inst.value_opnums)
+            for v in uses:
+                assert isinstance(v, Var)
+                s.add(v)
+
+            return s
 
         return reduce(flow_f, reversed(self.rtl), set([]))
 
@@ -106,8 +111,9 @@ class Rtl(object):
         # type: (Rtl) -> None
         """
         Given that there is only 1 possible concrete typing T for self, assign
-        a singleton TV with the single type t=T[v] for each Var v \in self.
-        Its an error to call this on an Rtl with more than 1 possible typing.
+        a singleton TV with type t=T[v] for each Var v \in self.  Its an error
+        to call this on an Rtl with more than 1 possible typing.  This modifies
+        the Rtl in-place.
         """
         from .ti import ti_rtl, TypeEnv
         # 1) Infer the types of all vars in res
@@ -122,10 +128,8 @@ class Rtl(object):
 
         # 3) Assign the only possible type to each variable.
         for v in typenv.vars:
-            if v.get_typevar().singleton_type() is not None:
-                continue
-
-            v.set_typevar(TypeVar.singleton(typing[v].singleton_type()))
+            assert typing[v].singleton_type() is not None
+            v.set_typevar(typing[v])
 
 
 class XForm(object):

--- a/lib/cretonne/meta/cdsl/xform.py
+++ b/lib/cretonne/meta/cdsl/xform.py
@@ -71,7 +71,7 @@ class Rtl(object):
         # type: () -> Set[Var]
         """ Return the set of free Vars used in self"""
         def flow_f(s, d):
-            # type: (Set[Var], Def):    Set[Var]
+            # type: (Set[Var], Def) -> Set[Var]
             """Compute the change in the set of free vars across a Def"""
             s = s.difference(set(d.defs))
             return s.union(set(a for a in d.expr.args if isinstance(a, Var)))

--- a/lib/cretonne/meta/semantics/elaborate.py
+++ b/lib/cretonne/meta/semantics/elaborate.py
@@ -44,15 +44,20 @@ def find_matching_xform(d):
 def cleanup_semantics(r, outputs):
     # type: (Rtl, Set[Var]) -> Rtl
     """
-    The elaboration process creates a lot of redundant instruction pairs of the
-    shape:
+    The elaboration process creates a lot of redundant prim_to_bv conversions.
+    Cleanup the following cases:
 
+    1) prim_to_bv/prim_from_bv pair:
         a.0 << prim_from_bv(bva.0)
         ...
-        bva.1 << prim_to_bv(a.0)
+        bva.1 << prim_to_bv(a.0)  <-- redundant, replace by bva.0
         ...
 
-    Contract these to ease manual inspection.
+    2) prim_to_bv/prim_to-bv pair:
+        bva.0 << prim_to_bv(a)
+        ...
+        bva.1 << prim_to_bv(a) <-- redundant, replace by bva.0
+        ...
     """
     new_defs = []  # type: List[Def]
     subst_m = {v: v for v in r.vars()}  # type: VarMap

--- a/lib/cretonne/meta/semantics/elaborate.py
+++ b/lib/cretonne/meta/semantics/elaborate.py
@@ -101,14 +101,15 @@ def elaborate(r):
     primitives = set(PRIMITIVES.instructions)
     idx = 0
 
-    outputs = r.definitions()
+    res = Rtl(*r.rtl)
+    outputs = res.definitions()
 
     while not fp:
-        assert r.is_concrete()
+        assert res.is_concrete()
         new_defs = []  # type: List[Def]
         fp = True
 
-        for d in r.rtl:
+        for d in res.rtl:
             inst = d.expr.inst
 
             if (inst not in primitives):
@@ -120,6 +121,6 @@ def elaborate(r):
             else:
                 new_defs.append(d)
 
-        r.rtl = tuple(new_defs)
+        res.rtl = tuple(new_defs)
 
-    return cleanup_semantics(r, outputs)
+    return cleanup_semantics(res, outputs)

--- a/lib/cretonne/meta/semantics/elaborate.py
+++ b/lib/cretonne/meta/semantics/elaborate.py
@@ -83,7 +83,12 @@ def find_matching_xform(d):
 
     for x in d.expr.inst.semantics:
         subst = d.substitution(x.src.rtl[0], {})
-        assert subst is not None
+
+        # There may not be a substitution if there are concrete Enumerator
+        # values in the src pattern. (e.g. specifying the semantics of icmp.eq,
+        # icmp.ge... as separate transforms)
+        if (subst is None):
+            continue
 
         if x.ti.permits({subst[v]: tv for (v, tv) in typing.items()}):
             res.append(x)

--- a/lib/cretonne/meta/semantics/elaborate.py
+++ b/lib/cretonne/meta/semantics/elaborate.py
@@ -57,20 +57,29 @@ def cleanup_semantics(r, outputs):
     new_defs = []  # type: List[Def]
     subst_m = {v: v for v in r.vars()}  # type: VarMap
     definition = {}  # type: Dict[Var, Def]
+    prim_to_bv_map = {}  # type: Dict[Var, Def]
 
     # Pass 1: Remove redundant prim_to_bv
     for d in r.rtl:
         inst = d.expr.inst
 
         if (inst == prim_to_bv):
-            if d.expr.args[0] in definition:
-                assert isinstance(d.expr.args[0], Var)
-                def_loc = definition[d.expr.args[0]]
+            arg = d.expr.args[0]
+            df = d.defs[0]
+            assert isinstance(arg, Var)
 
+            if arg in definition:
+                def_loc = definition[arg]
                 if def_loc.expr.inst == prim_from_bv:
                     assert isinstance(def_loc.expr.args[0], Var)
-                    subst_m[d.defs[0]] = def_loc.expr.args[0]
+                    subst_m[df] = def_loc.expr.args[0]
                     continue
+
+            if arg in prim_to_bv_map:
+                subst_m[df] = prim_to_bv_map[arg].defs[0]
+                continue
+
+            prim_to_bv_map[arg] = d
 
         new_def = d.copy(subst_m)
 

--- a/lib/cretonne/meta/semantics/primitives.py
+++ b/lib/cretonne/meta/semantics/primitives.py
@@ -9,11 +9,13 @@ from __future__ import absolute_import
 from cdsl.operands import Operand
 from cdsl.typevar import TypeVar
 from cdsl.instructions import Instruction, InstructionGroup
+from cdsl.ti import WiderOrEq
 import base.formats # noqa
 
 GROUP = InstructionGroup("primitive", "Primitive instruction set")
 
 BV = TypeVar('BV', 'A bitvector type.', bitvecs=True)
+BV1 = TypeVar('BV1', 'A single bit bitvector.', bitvecs=(1, 1))
 Real = TypeVar('Real', 'Any real type.', ints=True, floats=True,
                bools=True, simd=True)
 
@@ -65,5 +67,19 @@ bvadd = Instruction(
         of the operands.
         """,
         ins=(x, y), outs=a)
+
+# Bitvector comparisons
+cmp_res = Operand('cmp_res', BV1, doc="Single bit boolean")
+bvult = Instruction(
+        'bvult', r"""Unsigned bitvector comparison""",
+        ins=(x, y), outs=cmp_res)
+
+# Extensions
+ToBV = TypeVar('ToBV', 'A bitvector type.', bitvecs=True)
+x1 = Operand('x1', ToBV, doc="")
+
+bvzeroext = Instruction(
+        'bvzeroext', r"""Unsigned bitvector extension""",
+        ins=x, outs=x1, constraints=WiderOrEq(ToBV, BV))
 
 GROUP.close()

--- a/lib/cretonne/meta/semantics/smtlib.py
+++ b/lib/cretonne/meta/semantics/smtlib.py
@@ -1,0 +1,150 @@
+"""
+Tools to emit SMTLIB bitvector queries encoding concrete RTLs containing only
+primitive instructions.
+"""
+from .primitives import GROUP as PRIMITIVES, prim_from_bv, prim_to_bv, bvadd,\
+    bvult, bvzeroext
+from cdsl.ast import Var
+from cdsl.types import BVType
+
+try:
+    from typing import TYPE_CHECKING, Tuple # noqa
+    from cdsl.xform import Rtl # noqa
+    from cdsl.ast import VarMap # noqa
+except ImportError:
+    TYPE_CHECKING = False
+
+
+def bvtype_to_sort(typ):
+    # type: (BVType) -> str
+    """Return the BitVec sort corresponding to a BVType"""
+    return "(_ BitVec {})".format(typ.bits)
+
+
+def to_smt(r):
+    # type: (Rtl) -> Tuple[str, VarMap]
+    """
+    Encode a concrete primitive Rtl r sa SMTLIB 2.0 query.
+    Returns a tuple (query, var_m) where:
+        - query is the resulting query.
+        - var_m is a map from Vars v with non-BVType to their Vars v' with
+          BVType s.t. v' holds the flattend bitvector value of v.
+    """
+    assert r.is_concrete()
+    # Should contain only primitives
+    primitives = set(PRIMITIVES.instructions)
+    assert all(d.expr.inst in primitives for d in r.rtl)
+
+    q = ""
+    m = {}  # type: VarMap
+    for v in r.vars():
+        typ = v.get_typevar().singleton_type()
+        if not isinstance(typ, BVType):
+            continue
+
+        q += "(declare-fun {} () {})\n".format(v.name, bvtype_to_sort(typ))
+
+    for d in r.rtl:
+        inst = d.expr.inst
+
+        if inst == prim_to_bv:
+            assert isinstance(d.expr.args[0], Var)
+            m[d.expr.args[0]] = d.defs[0]
+            continue
+
+        if inst == prim_from_bv:
+            assert isinstance(d.expr.args[0], Var)
+            m[d.defs[0]] = d.expr.args[0]
+            continue
+
+        if inst in [bvadd, bvult]:  # Binary instructions
+            assert len(d.expr.args) == 2 and len(d.defs) == 1
+            lhs = d.expr.args[0]
+            rhs = d.expr.args[1]
+            df = d.defs[0]
+            assert isinstance(lhs, Var) and isinstance(rhs, Var)
+
+            if inst in [bvadd]:  # Normal binary - output type same as args
+                exp = "(= {} ({} {} {}))".format(df, inst.name, lhs, rhs)
+            else:
+                # Comparison binary - need to convert bool to BitVec 1
+                exp = "(= {} (ite ({} {} {}) #b1 #b0))"\
+                      .format(df, inst.name, lhs, rhs)
+        elif inst == bvzeroext:
+            arg = d.expr.args[0]
+            df = d.defs[0]
+            assert isinstance(arg, Var)
+            fromW = arg.get_typevar().singleton_type().width()
+            toW = df.get_typevar().singleton_type().width()
+
+            exp = "(= {} ((_ zero_extend {}) {}))"\
+                  .format(df, toW-fromW, arg, df)
+        else:
+            assert False, "Unknown primitive instruction {}".format(inst)
+
+        q += "(assert {})\n".format(exp)
+
+    return (q, m)
+
+
+def equivalent(r1, r2, m):
+    # type: (Rtl, Rtl, VarMap) -> str
+    """
+    Given concrete primitive Rtls r1 and r2, and a VarMap m, mapping all
+    non-primitive vars in r1 onto r2, return a query checking that the
+    two Rtls are semantically equivalent.
+
+    If the returned query is unsatisfiable, then r1 and r2 are equivalent.
+    Otherwise, the satisfying example for the query gives us values
+    for which the two Rtls disagree.
+    """
+    # Rename the vars in r1 and r2 to avoid conflicts
+    src_m = {v: Var(v.name + ".a", v.get_typevar()) for v in r1.vars()}
+    dst_m = {v: Var(v.name + ".b", v.get_typevar()) for v in r2.vars()}
+    m = {src_m[k]: dst_m[v] for (k, v) in m.items()}
+
+    r1 = r1.copy(src_m)
+    r2 = r2.copy(dst_m)
+
+    r1_nonprim_vars = set(
+        [v for v in r1.vars()
+         if not isinstance(v.get_typevar().singleton_type(), BVType)])
+
+    r2_nonprim_vars = set(
+        [v for v in r2.vars()
+         if not isinstance(v.get_typevar().singleton_type(), BVType)])
+
+    # Check that the map m maps all non real Cretone Vars from r1 onto r2
+    assert r1_nonprim_vars == set(m.keys())
+    assert r2_nonprim_vars == set(m.values())
+
+    (q1, m1) = to_smt(r1)
+    (q2, m2) = to_smt(r2)
+
+    # Build an expression for the equality of real Cretone inputs
+    args_eq_exp = "(and \n"
+
+    for v in r1.free_vars():
+        assert v in r1_nonprim_vars
+        args_eq_exp += "(= {} {})\n".format(m1[v], m2[m[v]])
+    args_eq_exp += ")"
+
+    # Build an expression for the equality of real Cretone defs
+    results_eq_exp = "(and \n"
+    for v in r1.definitions():
+        if (v not in r1_nonprim_vars):
+            continue
+
+        results_eq_exp += "(= {} {})\n".format(m1[v], m2[m[v]])
+    results_eq_exp += ")"
+
+    q = '; Rtl 1 declarations and assertions\n' + q1
+    q += '; Rtl 2 declarations and assertions\n' + q2
+
+    q += '; Assert that the inputs of Rtl1 and Rtl2 are equal\n' + \
+         '(assert {})\n'.format(args_eq_exp)
+
+    q += '; Assert that the outputs of Rtl1 and Rtl2 are not equal\n' + \
+         '(assert (not {}))\n'.format(results_eq_exp)
+
+    return q

--- a/lib/cretonne/meta/test_gen_legalizer.py
+++ b/lib/cretonne/meta/test_gen_legalizer.py
@@ -153,7 +153,7 @@ class TestRuntimeChecks(TestCase):
 
     def test_vselect_imm(self):
         # type: () -> None
-        ts = TypeSet(lanes=(2, 256), ints=(8, 64))
+        ts = TypeSet(lanes=(2, 256), ints=True, floats=True, bools=(8, 64))
         r = Rtl(
                 self.v0 << iconst(self.imm0),
                 self.v1 << icmp(intcc.eq, self.v2, self.v0),
@@ -166,7 +166,7 @@ class TestRuntimeChecks(TestCase):
             .format(self.v3.get_typevar().name)
 
         self.check_yo_check(
-            x, sequence(typeset_check(self.v2, ts),
+            x, sequence(typeset_check(self.v3, ts),
                         equiv_check(tv2_exp, tv3_exp)))
 
     def test_reduce_extend(self):


### PR DESCRIPTION
This PR adds bug fixes and machinery neccessary to express semantics of RTLs as smtlib queries for equivalence checking. In detail:
      1) bug fixes in TI to make sure tvs in a dest pattern are always expressed as a function of the free tvs in the source pattern
      2) cleanup - moving some routines such as apply(), is_concrete_rtl() and cleanup_concrete_rtl() from semantics/elaborate() to better suited locations in cdsl/xforms.py
      3) smtlib.py - routines for emitting queries for concretely typed Rtls
      4) Stricter constraints for binary conversion instructions
      5) additional semantic primitives and semantics for some arithmetic instructions, sufficient to emit queries checking iadd legalizations.