### PR TITLE
Added partial recompute of dominator tree in case of Ebb splitting 

### DIFF
--- a/lib/cretonne/src/dominator_tree.rs
+++ b/lib/cretonne/src/dominator_tree.rs
@@ -390,6 +390,7 @@ mod test {
     use flowgraph::ControlFlowGraph;
     use ir::{Function, InstBuilder, Cursor, types};
     use super::*;
+    use ir::types::*;
     use verifier::verify_context;
 
     #[test]
@@ -544,10 +545,11 @@ mod test {
             let cur = &mut Cursor::new(&mut func.layout);
 
             cur.insert_ebb(ebb0);
-            inst2 = dfg.ins(cur).trap();
-            inst3 = dfg.ins(cur).trap();
-            inst4 = dfg.ins(cur).trap();
-            inst5 = dfg.ins(cur).trap();
+            let cond = dfg.ins(cur).iconst(I32, 0);
+            inst2 = dfg.ins(cur).brz(cond, ebb0, &[]);
+            inst3 = dfg.ins(cur).brz(cond, ebb0, &[]);
+            inst4 = dfg.ins(cur).brz(cond, ebb0, &[]);
+            inst5 = dfg.ins(cur).brz(cond, ebb0, &[]);
             dfg.ins(cur).jump(ebb100, &[]);
             cur.insert_ebb(ebb100);
             dfg.ins(cur).return_(&[]);

--- a/lib/cretonne/src/flowgraph.rs
+++ b/lib/cretonne/src/flowgraph.rs
@@ -118,8 +118,8 @@ impl ControlFlowGraph {
     }
 
     fn add_edge(&mut self, from: BasicBlock, to: Ebb) {
-        self.data[from.0].successors.push(to);
-        self.data[to].predecessors.push(from);
+        self.data.ensure(from.0).successors.push(to);
+        self.data.ensure(to).predecessors.push(from);
     }
 
     /// Get the CFG predecessor basic blocks to `ebb`.

--- a/lib/cretonne/src/flowgraph.rs
+++ b/lib/cretonne/src/flowgraph.rs
@@ -118,8 +118,8 @@ impl ControlFlowGraph {
     }
 
     fn add_edge(&mut self, from: BasicBlock, to: Ebb) {
-        self.data.ensure(from.0).successors.push(to);
-        self.data.ensure(to).predecessors.push(from);
+        self.data[from.0].successors.push(to);
+        self.data[to].predecessors.push(from);
     }
 
     /// Get the CFG predecessor basic blocks to `ebb`.

--- a/lib/cretonne/src/verifier/mod.rs
+++ b/lib/cretonne/src/verifier/mod.rs
@@ -63,6 +63,8 @@ use std::error as std_error;
 use std::fmt::{self, Display, Formatter};
 use std::result;
 use std::collections::BTreeSet;
+use std::cmp::Ordering;
+use iterators::IteratorExtras;
 
 pub use self::liveness::verify_liveness;
 pub use self::cssa::verify_cssa;
@@ -407,6 +409,30 @@ impl<'a> Verifier<'a> {
                             ebb,
                             expected,
                             got);
+            }
+        }
+        // We also verify if the postorder defined by `DominatorTree` is sane
+        for (index, (&true_ebb, &test_ebb)) in
+            self.domtree
+                .cfg_postorder()
+                .iter()
+                .zip(domtree.cfg_postorder().iter())
+                .enumerate() {
+            if true_ebb != test_ebb {
+                return err!(test_ebb,
+                            "invalid domtree, postorder ebb number {} should be {}, got {}",
+                            index,
+                            true_ebb,
+                            test_ebb);
+            }
+        }
+        // We verify rpo_cmp on pairs of adjacent ebbs in the postorder
+        for (&prev_ebb, &next_ebb) in self.domtree.cfg_postorder().iter().adjacent_pairs() {
+            if domtree.rpo_cmp(prev_ebb, next_ebb, &self.func.layout) != Ordering::Greater {
+                return err!(next_ebb,
+                            "invalid domtree, rpo_cmp does not says {} is greater than {}",
+                            prev_ebb,
+                            next_ebb);
             }
         }
         Ok(())

--- a/lib/cretonne/src/verifier/mod.rs
+++ b/lib/cretonne/src/verifier/mod.rs
@@ -412,6 +412,10 @@ impl<'a> Verifier<'a> {
             }
         }
         // We also verify if the postorder defined by `DominatorTree` is sane
+        if self.domtree.cfg_postorder().len() != domtree.cfg_postorder().len() {
+            return err!(AnyEntity::Function,
+                        "incorrect number of Ebbs in postorder traversal");
+        }
         for (index, (&true_ebb, &test_ebb)) in
             self.domtree
                 .cfg_postorder()


### PR DESCRIPTION
Implemented via striding RPO numbers and renumbering in worst case.