### PR TITLE
Verifier now checks it branch target ebbs are inserted in the layout

### DIFF
--- a/lib/cretonne/src/verifier/mod.rs
+++ b/lib/cretonne/src/verifier/mod.rs
@@ -297,7 +297,7 @@ impl<'a> Verifier<'a> {
     }
 
     fn verify_ebb(&self, inst: Inst, e: Ebb) -> Result {
-        if !self.func.dfg.ebb_is_valid(e) {
+        if !self.func.dfg.ebb_is_valid(e) || !self.func.layout.is_ebb_inserted(e) {
             err!(inst, "invalid ebb reference {}", e)
         } else {
             Ok(())


### PR DESCRIPTION
This was a blind spot in the verifier, because of it I missed a bug in the `wasm2cretonne` translation.