### PR TITLE
Fix for  #141

### DIFF
--- a/lib/cretonne/meta/cdsl/operands.py
+++ b/lib/cretonne/meta/cdsl/operands.py
@@ -5,10 +5,10 @@ from .types import ValueType
 from .typevar import TypeVar
 
 try:
-    from typing import Union, Dict, TYPE_CHECKING  # noqa
+    from typing import Union, Dict, TYPE_CHECKING, Iterable  # noqa
     OperandSpec = Union['OperandKind', ValueType, TypeVar]
     if TYPE_CHECKING:
-        from .ast import Enumerator, ConstantInt  # noqa
+        from .ast import Enumerator, ConstantInt, Literal  # noqa
 except ImportError:
     pass
 
@@ -127,6 +127,17 @@ class ImmediateKind(OperandKind):
         Get the qualified Rust name of the enumerator value `value`.
         """
         return '{}::{}'.format(self.rust_type, self.values[value])
+
+    def is_enumeratable(self):
+        # type: () -> bool
+        return self.values is not None
+
+    def possible_values(self):
+        # type: () -> Iterable[Literal]
+        from cdsl.ast import Enumerator # noqa
+        assert self.is_enumeratable()
+        for v in self.values.keys():
+            yield Enumerator(self, v)
 
 
 # Instances of entity reference operand types are provided in the

--- a/lib/cretonne/meta/cdsl/operands.py
+++ b/lib/cretonne/meta/cdsl/operands.py
@@ -128,14 +128,14 @@ class ImmediateKind(OperandKind):
         """
         return '{}::{}'.format(self.rust_type, self.values[value])
 
-    def is_enumeratable(self):
+    def is_enumerable(self):
         # type: () -> bool
         return self.values is not None
 
     def possible_values(self):
         # type: () -> Iterable[Literal]
         from cdsl.ast import Enumerator # noqa
-        assert self.is_enumeratable()
+        assert self.is_enumerable()
         for v in self.values.keys():
             yield Enumerator(self, v)
 

--- a/lib/cretonne/meta/cdsl/test_xform.py
+++ b/lib/cretonne/meta/cdsl/test_xform.py
@@ -80,15 +80,52 @@ class TestXForm(TestCase):
         dst = Rtl(b << icmp(intcc.eq, z, u))
         assert src.substitution(dst, {}) == {a: b, x: z, y: u}
 
-    def test_subst_enum_bad(self):
+    def test_subst_enum_var_const(self):
         src = Rtl(a << icmp(CC1, x, y))
         dst = Rtl(b << icmp(intcc.eq, z, u))
-        assert src.substitution(dst, {}) is None
+        assert src.substitution(dst, {}) == {CC1: intcc.eq, x: z, y: u, a: b},\
+            "{} != {}".format(src.substitution(dst, {}),
+                              {CC1: intcc.eq, x: z, y: u, a: b})
 
         src = Rtl(a << icmp(intcc.eq, x, y))
         dst = Rtl(b << icmp(CC1, z, u))
-        assert src.substitution(dst, {}) is None
+        assert src.substitution(dst, {}) == {CC1: intcc.eq, x: z, y: u, a: b}
 
+    def test_subst_enum_bad(self):
         src = Rtl(a << icmp(intcc.eq, x, y))
         dst = Rtl(b << icmp(intcc.sge, z, u))
+        assert src.substitution(dst, {}) is None
+
+    def test_subst_enum_bad_var_const(self):
+        a1 = Var('a1')
+        x1 = Var('x1')
+        y1 = Var('y1')
+
+        b1 = Var('b1')
+        z1 = Var('z1')
+        u1 = Var('u1')
+
+        # Var mapping to 2 different constants
+        src = Rtl(a << icmp(CC1, x, y),
+                  a1 << icmp(CC1, x1, y1))
+        dst = Rtl(b << icmp(intcc.eq, z, u),
+                  b1 << icmp(intcc.sge, z1, u1))
+
+        assert src.substitution(dst, {}) is None
+
+        # 2 different constants mapping to the same var
+        src = Rtl(a << icmp(intcc.eq, x, y),
+                  a1 << icmp(intcc.sge, x1, y1))
+        dst = Rtl(b << icmp(CC1, z, u),
+                  b1 << icmp(CC1, z1, u1))
+
+        assert src.substitution(dst, {}) is None
+
+        # Var mapping to var and constant - note that full unification would
+        # have allowed this.
+        src = Rtl(a << icmp(CC1, x, y),
+                  a1 << icmp(CC1, x1, y1))
+        dst = Rtl(b << icmp(CC2, z, u),
+                  b1 << icmp(intcc.sge, z1, u1))
+
         assert src.substitution(dst, {}) is None

--- a/lib/cretonne/meta/cdsl/xform.py
+++ b/lib/cretonne/meta/cdsl/xform.py
@@ -9,7 +9,7 @@ from functools import reduce
 try:
     from typing import Union, Iterator, Sequence, Iterable, List, Dict  # noqa
     from typing import Optional, Set # noqa
-    from .ast import Expr, VarMap  # noqa
+    from .ast import Expr, VarAtomMap  # noqa
     from .isa import TargetISA  # noqa
     from .ti import TypeConstraint  # noqa
     from .typevar import TypeVar  # noqa
@@ -47,7 +47,7 @@ class Rtl(object):
         self.rtl = tuple(map(canonicalize_defapply, args))
 
     def copy(self, m):
-        # type: (VarMap) -> Rtl
+        # type: (VarAtomMap) -> Rtl
         """
         Return a copy of this rtl with all Vars substituted with copies or
         according to m. Update m as neccessary.
@@ -85,7 +85,7 @@ class Rtl(object):
         return reduce(flow_f, reversed(self.rtl), set([]))
 
     def substitution(self, other, s):
-        # type: (Rtl, VarMap) -> Optional[VarMap]
+        # type: (Rtl, VarAtomMap) -> Optional[VarAtomMap]
         """
         If the Rtl self agrees structurally with the Rtl other, return a
         substitution to transform self to other. Two Rtls agree structurally if
@@ -333,7 +333,7 @@ class XForm(object):
         defs are renamed with '.suffix' appended to their old name.
         """
         assert r.is_concrete()
-        s = self.src.substitution(r, {})  # type: VarMap
+        s = self.src.substitution(r, {})  # type: VarAtomMap
         assert s is not None
 
         if (suffix is not None):

--- a/lib/cretonne/meta/cdsl/xform.py
+++ b/lib/cretonne/meta/cdsl/xform.py
@@ -3,7 +3,7 @@ Instruction transformations.
 """
 from __future__ import absolute_import
 from .ast import Def, Var, Apply
-from .ti import ti_xform, TypeEnv, get_type_env
+from .ti import ti_xform, TypeEnv, get_type_env, TypeConstraint
 from functools import reduce
 
 try:
@@ -11,8 +11,8 @@ try:
     from typing import Optional, Set # noqa
     from .ast import Expr, VarAtomMap  # noqa
     from .isa import TargetISA  # noqa
-    from .ti import TypeConstraint  # noqa
     from .typevar import TypeVar  # noqa
+    from .instructions import ConstrList # noqa
     DefApply = Union[Def, Apply]
 except ImportError:
     pass
@@ -132,6 +132,10 @@ class Rtl(object):
             assert typing[v].singleton_type() is not None
             v.set_typevar(typing[v])
 
+    def __str__(self):
+        # type: () -> str
+        return "\n".join(map(str, self.rtl))
+
 
 class XForm(object):
     """
@@ -162,7 +166,7 @@ class XForm(object):
     """
 
     def __init__(self, src, dst, constraints=None):
-        # type: (Rtl, Rtl, Optional[Sequence[TypeConstraint]]) -> None
+        # type: (Rtl, Rtl, Optional[ConstrList]) -> None
         self.src = src
         self.dst = dst
         # Variables that are inputs to the source pattern.
@@ -203,10 +207,18 @@ class XForm(object):
                 return tv
             return symtab[tv.name[len("typeof_"):]].get_typevar()
 
+        self.constraints = []  # type: List[TypeConstraint]
         if constraints is not None:
-            for c in constraints:
+            if isinstance(constraints, TypeConstraint):
+                constr_list = [constraints]  # type: Sequence[TypeConstraint]
+            else:
+                constr_list = constraints
+
+            for c in constr_list:
                 type_m = {tv: interp_tv(tv) for tv in c.tvs()}
-                self.ti.add_constraint(c.translate(type_m))
+                inner_c = c.translate(type_m)
+                self.constraints.append(inner_c)
+                self.ti.add_constraint(inner_c)
 
         # Sanity: The set of inferred free typevars should be a subset of the
         # TVs corresponding to Vars appearing in src

--- a/lib/cretonne/meta/gen_legalizer.py
+++ b/lib/cretonne/meta/gen_legalizer.py
@@ -21,7 +21,7 @@ from cdsl.typevar import TypeVar
 try:
     from typing import Sequence, List, Dict, Set, DefaultDict # noqa
     from cdsl.isa import TargetISA  # noqa
-    from cdsl.ast import Def  # noqa
+    from cdsl.ast import Def, VarAtomMap  # noqa
     from cdsl.xform import XForm, XFormGroup  # noqa
     from cdsl.typevar import TypeSet # noqa
     from cdsl.ti import TypeConstraint # noqa
@@ -45,7 +45,7 @@ def get_runtime_typechecks(xform):
     # 1) Perform ti only on the source RTL. Accumulate any free tvs that have a
     #    different inferred type in src, compared to the type inferred for both
     #    src and dst.
-    symtab = {}  # type: Dict[Var, Var]
+    symtab = {}  # type: VarAtomMap
     src_copy = xform.src.copy(symtab)
     src_typenv = get_type_env(ti_rtl(src_copy, TypeEnv()))
 
@@ -62,7 +62,9 @@ def get_runtime_typechecks(xform):
             assert v.get_typevar().singleton_type() is not None
             continue
 
-        src_ts = src_typenv[symtab[v]].get_typeset()
+        inner_v = symtab[v]
+        assert isinstance(inner_v, Var)
+        src_ts = src_typenv[inner_v].get_typeset()
         xform_ts = xform.ti[v].get_typeset()
 
         assert xform_ts.issubset(src_ts)

--- a/lib/cretonne/meta/semantics/__init__.py
+++ b/lib/cretonne/meta/semantics/__init__.py
@@ -1,9 +1,10 @@
 """Definitions for the semantics segment of the Cretonne language."""
 from cdsl.ti import TypeEnv, ti_rtl, get_type_env
+from cdsl.operands import ImmediateKind
 
 try:
     from typing import List, Dict, Tuple # noqa
-    from cdsl.ast import Var # noqa
+    from cdsl.ast import Var, VarAtomMap # noqa
     from cdsl.xform import XForm, Rtl # noqa
     from cdsl.ti import VarTyping # noqa
     from cdsl.instructions import Instruction, InstructionSemantics # noqa
@@ -16,34 +17,60 @@ def verify_semantics(inst, src, xforms):
     """
     Verify that the semantics transforms in xforms correctly describe the
     instruction described by the src Rtl.  This involves checking that:
-        1) For all XForms x \in xforms, there is a Var substitution form src to
-           x.src
-        2) For any possible concrete typing of src there is exactly 1 XForm x
-           in xforms that applies.
+        0) src is a single instance of inst
+        1) For all x\in xforms x.src is a single instance of inst
+        2) For any concrete values V of Literals in inst:
+            For all concrete typing T of inst:
+                Exists single x \in xforms that applies to src conretazied to V
+                and T
     """
-    # 0) The source rtl is always a single instruction
-    assert len(src.rtl) == 1
+    # 0) The source rtl is always a single instance of inst
+    assert len(src.rtl) == 1 and src.rtl[0].expr.inst == inst
 
-    # 1) For all XForms x, x.src is structurally equivalent to src
+    # 1) For all XForms x, x.src is a single instance of inst
     for x in xforms:
-        assert src.substitution(x.src, {}) is not None,\
-            "XForm {} doesn't describe instruction {}.".format(x, src)
+        assert len(x.src.rtl) == 1 and x.src.rtl[0].expr.inst == inst
 
-    # 2) Any possible typing for the instruction should be covered by
-    #    exactly ONE semantic XForm
-    src = src.copy({})
-    typenv = get_type_env(ti_rtl(src, TypeEnv()))
-    typenv.normalize()
-    typenv = typenv.extract()
+    variants = [src]  # type: List[Rtl]
 
-    for t in typenv.concrete_typings():
-        matching_xforms = []  # type: List[XForm]
-        for x in xforms:
-            # Translate t using x.symtab
-            t = {x.symtab[str(v)]:  tv for (v, tv) in t.items()}
-            if (x.ti.permits(t)):
-                matching_xforms.append(x)
+    # 2) For all enumerated immediates, compute all the possible
+    #    versions of src with the concrete value filled in.
+    for i in inst.imm_opnums:
+        op = inst.ins[i]
+        if not (isinstance(op.kind, ImmediateKind) and
+                op.kind.is_enumeratable()):
+            continue
 
-        assert len(matching_xforms) == 1,\
-            ("Possible typing {} of {} not matched by exactly one case " +
-             ": {}").format(t, inst, matching_xforms)
+        new_variants = []  # type: List[Rtl]
+        for rtl_var in variants:
+            s = {v: v for v in rtl_var.vars()}  # type: VarAtomMap
+            arg = rtl_var.rtl[0].expr.args[i]
+            assert isinstance(arg, Var)
+            for val in op.kind.possible_values():
+                    s[arg] = val
+                    new_variants.append(rtl_var.copy(s))
+        variants = new_variants
+
+    # For any possible version of the src with concrete enumerated immediates
+    for src in variants:
+        # 2) Any possible typing should be covered by exactly ONE semantic
+        # XForm
+        src = src.copy({})
+        typenv = get_type_env(ti_rtl(src, TypeEnv()))
+        typenv.normalize()
+        typenv = typenv.extract()
+
+        for t in typenv.concrete_typings():
+            matching_xforms = []  # type: List[XForm]
+            for x in xforms:
+                if src.substitution(x.src, {}) is None:
+                        continue
+
+                # Translate t using x.symtab
+                t = {x.symtab[str(v)]:  tv for (v, tv) in t.items()}
+                if (x.ti.permits(t)):
+                    matching_xforms.append(x)
+
+            assert len(matching_xforms) == 1,\
+                ("Possible typing {} of {} not matched by exactly one case " +
+                 ": {}").format(t, src.rtl[0], matching_xforms)

--- a/lib/cretonne/meta/semantics/__init__.py
+++ b/lib/cretonne/meta/semantics/__init__.py
@@ -1,10 +1,11 @@
 """Definitions for the semantics segment of the Cretonne language."""
 from cdsl.ti import TypeEnv, ti_rtl, get_type_env
 from cdsl.operands import ImmediateKind
+from cdsl.ast import Var
 
 try:
     from typing import List, Dict, Tuple # noqa
-    from cdsl.ast import Var, VarAtomMap # noqa
+    from cdsl.ast import VarAtomMap  # noqa
     from cdsl.xform import XForm, Rtl # noqa
     from cdsl.ti import VarTyping # noqa
     from cdsl.instructions import Instruction, InstructionSemantics # noqa

--- a/lib/cretonne/meta/semantics/__init__.py
+++ b/lib/cretonne/meta/semantics/__init__.py
@@ -39,7 +39,7 @@ def verify_semantics(inst, src, xforms):
     for i in inst.imm_opnums:
         op = inst.ins[i]
         if not (isinstance(op.kind, ImmediateKind) and
-                op.kind.is_enumeratable()):
+                op.kind.is_enumerable()):
             continue
 
         new_variants = []  # type: List[Rtl]

--- a/lib/cretonne/meta/semantics/elaborate.py
+++ b/lib/cretonne/meta/semantics/elaborate.py
@@ -10,7 +10,7 @@ from cdsl.ast import Var
 try:
     from typing import TYPE_CHECKING, Dict, Union, List, Set, Tuple # noqa
     from cdsl.xform import XForm # noqa
-    from cdsl.ast import Def, VarMap # noqa
+    from cdsl.ast import Def, VarAtomMap # noqa
     from cdsl.ti import VarTyping # noqa
 except ImportError:
     TYPE_CHECKING = False
@@ -34,7 +34,13 @@ def find_matching_xform(d):
         if (subst is None):
             continue
 
-        if x.ti.permits({subst[v]: tv for (v, tv) in typing.items()}):
+        inner_typing = {}  # type: VarTyping
+        for (v, tv) in typing.items():
+            inner_v = subst[v]
+            assert isinstance(inner_v, Var)
+            inner_typing[inner_v] = tv
+
+        if x.ti.permits(inner_typing):
             res.append(x)
 
     assert len(res) == 1, "Couldn't find semantic transform for {}".format(d)
@@ -60,7 +66,7 @@ def cleanup_semantics(r, outputs):
         ...
     """
     new_defs = []  # type: List[Def]
-    subst_m = {v: v for v in r.vars()}  # type: VarMap
+    subst_m = {v: v for v in r.vars()}  # type: VarAtomMap
     definition = {}  # type: Dict[Var, Def]
     prim_to_bv_map = {}  # type: Dict[Var, Def]
 

--- a/lib/cretonne/meta/semantics/macros.py
+++ b/lib/cretonne/meta/semantics/macros.py
@@ -1,0 +1,45 @@
+"""
+Useful semantics "macro" instructions built on top of
+the primitives.
+"""
+from __future__ import absolute_import
+from cdsl.operands import Operand
+from cdsl.typevar import TypeVar
+from cdsl.instructions import Instruction, InstructionGroup
+from base.types import b1
+from base.immediates import imm64
+from cdsl.ast import Var
+from cdsl.xform import Rtl
+from semantics.primitives import bv_from_imm64, bvite
+import base.formats # noqa
+
+GROUP = InstructionGroup("primitive_macros", "Semantic macros instruction set")
+AnyBV = TypeVar('AnyBV', bitvecs=True, doc="")
+x = Var('x')
+y = Var('y')
+imm = Var('imm')
+a = Var('a')
+
+#
+# Bool-to-bv1
+#
+BV1 = TypeVar("BV1", bitvecs=(1, 1), doc="")
+bv1_op = Operand('bv1_op', BV1, doc="")
+cond_op = Operand("cond", b1, doc="")
+bool2bv = Instruction(
+        'bool2bv', r"""Convert a b1 value to a 1-bit BV""",
+        ins=cond_op, outs=bv1_op)
+
+v1 = Var('v1')
+v2 = Var('v2')
+bvone = Var('bvone')
+bvzero = Var('bvzero')
+bool2bv.set_semantics(
+        v1 << bool2bv(v2),
+        Rtl(
+            bvone << bv_from_imm64(imm64(1)),
+            bvzero << bv_from_imm64(imm64(0)),
+            v1 << bvite(v2, bvone, bvzero)
+        ))
+
+GROUP.close()

--- a/lib/cretonne/meta/semantics/primitives.py
+++ b/lib/cretonne/meta/semantics/primitives.py
@@ -10,6 +10,8 @@ from cdsl.operands import Operand
 from cdsl.typevar import TypeVar
 from cdsl.instructions import Instruction, InstructionGroup
 from cdsl.ti import WiderOrEq
+from base.types import b1
+from base.immediates import imm64
 import base.formats # noqa
 
 GROUP = InstructionGroup("primitive", "Primitive instruction set")
@@ -22,25 +24,39 @@ Real = TypeVar('Real', 'Any real type.', ints=True, floats=True,
 x = Operand('x', BV, doc="A semantic value X")
 y = Operand('x', BV, doc="A semantic value Y (same width as X)")
 a = Operand('a', BV, doc="A semantic value A (same width as X)")
+cond = Operand('b', TypeVar.singleton(b1), doc='A b1 value')
 
 real = Operand('real', Real, doc="A real cretonne value")
 fromReal = Operand('fromReal', Real.to_bitvec(),
                    doc="A real cretonne value converted to a BV")
 
+#
+# BV Conversion/Materialization
+#
 prim_to_bv = Instruction(
         'prim_to_bv', r"""
         Convert an SSA Value to a flat bitvector
         """,
         ins=(real), outs=(fromReal))
 
-# Note that when converting from BV->real values, we use a constraint and not a
-# derived function. This reflects that fact that to_bitvec() is not a
-# bijection.
 prim_from_bv = Instruction(
         'prim_from_bv', r"""
         Convert a flat bitvector to a real SSA Value.
         """,
         ins=(fromReal), outs=(real))
+
+N = Operand('N', imm64)
+bv_from_imm64 = Instruction(
+        'bv_from_imm64', r"""Materialize an imm64 as a bitvector.""",
+        ins=(N), outs=a)
+
+#
+# Generics
+#
+bvite = Instruction(
+        'bvite', r"""Bitvector ternary operator""",
+        ins=(cond, x, y), outs=a)
+
 
 xh = Operand('xh', BV.half_width(),
              doc="A semantic value representing the upper half of X")
@@ -67,12 +83,40 @@ bvadd = Instruction(
         of the operands.
         """,
         ins=(x, y), outs=a)
-
+#
 # Bitvector comparisons
-cmp_res = Operand('cmp_res', BV1, doc="Single bit boolean")
+#
+
+bveq = Instruction(
+        'bveq', r"""Unsigned bitvector equality""",
+        ins=(x, y), outs=cond)
+bvne = Instruction(
+        'bveq', r"""Unsigned bitvector inequality""",
+        ins=(x, y), outs=cond)
+bvsge = Instruction(
+        'bvsge', r"""Signed bitvector greater or equal""",
+        ins=(x, y), outs=cond)
+bvsgt = Instruction(
+        'bvsgt', r"""Signed bitvector greater than""",
+        ins=(x, y), outs=cond)
+bvsle = Instruction(
+        'bvsle', r"""Signed bitvector less than or equal""",
+        ins=(x, y), outs=cond)
+bvslt = Instruction(
+        'bvslt', r"""Signed bitvector less than""",
+        ins=(x, y), outs=cond)
+bvuge = Instruction(
+        'bvuge', r"""Unsigned bitvector greater or equal""",
+        ins=(x, y), outs=cond)
+bvugt = Instruction(
+        'bvugt', r"""Unsigned bitvector greater than""",
+        ins=(x, y), outs=cond)
+bvule = Instruction(
+        'bvule', r"""Unsigned bitvector less than or equal""",
+        ins=(x, y), outs=cond)
 bvult = Instruction(
-        'bvult', r"""Unsigned bitvector comparison""",
-        ins=(x, y), outs=cmp_res)
+        'bvult', r"""Unsigned bitvector less than""",
+        ins=(x, y), outs=cond)
 
 # Extensions
 ToBV = TypeVar('ToBV', 'A bitvector type.', bitvecs=True)

--- a/lib/cretonne/meta/semantics/test_elaborate.py
+++ b/lib/cretonne/meta/semantics/test_elaborate.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from base.instructions import vselect, vsplit, vconcat, iconst, iadd, bint
 from base.instructions import b1, icmp, ireduce, iadd_cout
-from base.immediates import intcc
+from base.immediates import intcc, imm64
 from base.types import i64, i8, b32, i32, i16, f32
 from cdsl.typevar import TypeVar
 from cdsl.ast import Var
@@ -9,7 +9,7 @@ from cdsl.xform import Rtl
 from unittest import TestCase
 from .elaborate import elaborate
 from .primitives import prim_to_bv, bvsplit, prim_from_bv, bvconcat, bvadd, \
-    bvult
+    bvult, bv_from_imm64, bvite
 import base.semantics  # noqa
 
 
@@ -366,9 +366,12 @@ class TestElaborate(TestCase):
         a = Var('a')
         c_out = Var('c_out')
         bvc_out = Var('bvc_out')
+        bc_out = Var('bc_out')
         bvx = Var('bvx')
         bvy = Var('bvy')
         bva = Var('bva')
+        bvone = Var('bvone')
+        bvzero = Var('bvzero')
         r = Rtl(
                 (a, c_out) << iadd_cout.i32(x, y),
         )
@@ -378,10 +381,12 @@ class TestElaborate(TestCase):
             bvx << prim_to_bv.i32(x),
             bvy << prim_to_bv.i32(y),
             bva << bvadd.bv32(bvx, bvy),
-            bvc_out << bvult.bv32(bva, bvx),
+            bc_out << bvult.bv32(bva, bvx),
+            bvone << bv_from_imm64(imm64(1)),
+            bvzero << bv_from_imm64(imm64(0)),
+            bvc_out << bvite(bc_out, bvone, bvzero),
             a << prim_from_bv.i32(bva),
             c_out << prim_from_bv.b1(bvc_out)
         )
         exp.cleanup_concrete_rtl()
-
         assert concrete_rtls_eq(sem, exp)


### PR DESCRIPTION
This PR proposes a fix for #141. Namely it:
     - Adds a new `Expr` subclass `Literal`, (base class for `ConstantInt`, `Enumerator`...)
     - Adds support for substitutions `Var`->`Literal`, `Literal`->`Var` in {`Ast`, `Def`,`Rtl`}.{`copy()`, `substitution()`}
     - Changes `verify_semantics()` to enumerate all concrete values of enumerable immediates on top of enumerating all concrete typings.
     - As a proof of concept, adds correct semantics for `icmp`, along with the necessary primitives
     - Additional type checking for `Literal` kinds in `Apply.__init__()`
