### PR TITLE
Replace SSABuilder's variables HashMaps with EntityMaps.

### DIFF
--- a/lib/cretonne/src/entity/map.rs
+++ b/lib/cretonne/src/entity/map.rs
@@ -44,8 +44,7 @@ where
     /// Create a new empty map with a specified default value.
     ///
     /// This constructor does not require V to implement Default.
-    pub fn with_default(default: V) -> Self
-    {
+    pub fn with_default(default: V) -> Self {
         EntityMap {
             elems: Vec::new(),
             default: default,

--- a/lib/cretonne/src/entity/map.rs
+++ b/lib/cretonne/src/entity/map.rs
@@ -99,6 +99,16 @@ where
     }
 }
 
+impl<K, V> Default for EntityMap<K, V>
+where
+    K: EntityRef,
+    V: Clone + Default
+{
+    fn default() -> Self {
+        EntityMap::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/cretonne/src/entity/map.rs
+++ b/lib/cretonne/src/entity/map.rs
@@ -41,6 +41,18 @@ where
         }
     }
 
+    /// Create a new empty map with a specified default value.
+    ///
+    /// This constructor does not require V to implement Default.
+    pub fn with_default(default: V) -> Self
+    {
+        EntityMap {
+            elems: Vec::new(),
+            default: default,
+            unused: PhantomData,
+        }
+    }
+
     /// Get the element at `k` if it exists.
     pub fn get(&self, k: K) -> Option<&V> {
         self.elems.get(k.index())
@@ -96,16 +108,6 @@ where
             self.resize(i + 1);
         }
         &mut self.elems[i]
-    }
-}
-
-impl<K, V> Default for EntityMap<K, V>
-where
-    K: EntityRef,
-    V: Clone + Default
-{
-    fn default() -> Self {
-        EntityMap::new()
     }
 }
 

--- a/lib/cretonne/src/ir/entities.rs
+++ b/lib/cretonne/src/ir/entities.rs
@@ -55,6 +55,12 @@ impl Value {
     }
 }
 
+impl Default for Value {
+    fn default() -> Value {
+        Value(u32::MAX)
+    }
+}
+
 /// An opaque reference to an instruction in a function.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct Inst(u32);

--- a/lib/cretonne/src/ir/entities.rs
+++ b/lib/cretonne/src/ir/entities.rs
@@ -55,12 +55,6 @@ impl Value {
     }
 }
 
-impl Default for Value {
-    fn default() -> Value {
-        Value(u32::MAX)
-    }
-}
-
 /// An opaque reference to an instruction in a function.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct Inst(u32);

--- a/lib/frontend/src/ssa.rs
+++ b/lib/frontend/src/ssa.rs
@@ -227,10 +227,8 @@ where
     ) -> (Value, SideEffects) {
         // First we lookup for the current definition of the variable in this block
         if let Some(var_defs) = self.variables.get(var) {
-            if let Some(packed) = var_defs.get(block) {
-                if let Some(val) = packed.expand() {
-                    return (val, SideEffects::new());
-                }
+            if let Some(val) = var_defs[block].expand() {
+                return (val, SideEffects::new());
             }
         }
 


### PR DESCRIPTION
Current measurements show that memory usage is approximately the same,
and it's about 20% faster.