### PR TITLE
Change translate_module to use FuncTranslator.

### DIFF
--- a/lib/wasm/Cargo.toml
+++ b/lib/wasm/Cargo.toml
@@ -11,6 +11,6 @@ license = "Apache-2.0"
 name = "cton_wasm"
 
 [dependencies]
-wasmparser = "0.9.4"
+wasmparser = "0.10.0"
 cretonne = { path = "../cretonne" }
 cretonne-frontend = { path = "../frontend" }


### PR DESCRIPTION
The highlight of this patch is the removal of `translate_function_body` which has been subsumed by `FuncTranslator`.