### PR TITLE
Use --all in some scripts.

### DIFF
--- a/format-all.sh
+++ b/format-all.sh
@@ -6,12 +6,8 @@
 set -e
 
 cd $(dirname "$0")
-src=$(pwd)
 
 # Make sure we can find rustfmt.
 export PATH="$PATH:$HOME/.cargo/bin"
 
-for crate in $(find "$src" -name Cargo.toml); do
-    cd $(dirname "$crate")
-    cargo fmt -- "$@"
-done
+exec cargo fmt --all -- "$@"

--- a/test-all.sh
+++ b/test-all.sh
@@ -40,14 +40,9 @@ if [ -n "$needcheck" ]; then
     touch $tsfile || echo no target directory
 fi
 
-PKGS="cretonne cretonne-reader cretonne-tools cretonne-frontend cretonne-wasm \
-      filecheck "
 cd "$topdir"
-for PKG in $PKGS
-do
-    banner "Rust $PKG unit tests"
-    cargo test -p $PKG
-done
+banner "Rust unit tests"
+cargo test --all
 
 # Build cton-util for parser testing.
 cd "$topdir"


### PR DESCRIPTION
This avoids the need to list all the packages in test-all.sh.