### PR TITLE
Simplify targets and settings for cton-util wasm.

### DIFF
--- a/filetests/licm/basic.cton
+++ b/filetests/licm/basic.cton
@@ -1,5 +1,8 @@
 test licm
 
+; Target chosen arbitrarily
+isa riscv
+
 function %simple_loop(i32) -> i32 {
 
 ebb1(v0: i32):

--- a/filetests/licm/complex.cton
+++ b/filetests/licm/complex.cton
@@ -1,5 +1,8 @@
 test licm
 
+; Target chosen arbitrarily
+isa riscv
+
 function %complex(i32) -> i32 {
 
 ebb0(v0: i32):

--- a/filetests/licm/multiple-blocks.cton
+++ b/filetests/licm/multiple-blocks.cton
@@ -1,5 +1,8 @@
 test licm
 
+; Target chosen arbitrarily
+isa riscv
+
 function %multiple_blocks(i32) -> i32 {
 
 ebb0(v0: i32):

--- a/filetests/licm/nested_loops.cton
+++ b/filetests/licm/nested_loops.cton
@@ -1,5 +1,8 @@
 test licm
 
+; Target chosen arbitrarily
+isa riscv
+
 function %nested_loops(i32) -> i32 {
 
 ebb0(v0: i32):

--- a/filetests/simple_gvn/basic.cton
+++ b/filetests/simple_gvn/basic.cton
@@ -1,5 +1,8 @@
 test simple-gvn
 
+; Target chosen arbitrarily
+isa riscv
+
 function %simple_redundancy(i32, i32) -> i32 {
 ebb0(v0: i32, v1: i32):
     v2 = iadd v0, v1

--- a/filetests/simple_gvn/reject.cton
+++ b/filetests/simple_gvn/reject.cton
@@ -1,12 +1,15 @@
 test simple-gvn
 
+; Target chosen arbitrarily
+isa riscv
+
 function %other_side_effects(i32) -> i32 {
 ebb0(v0: i32):
-   regmove v0, %10 -> %20
-   regmove v0, %10 -> %20
-   regmove v0, %20 -> %10
-; check: regmove v0, %10 -> %20
-; check: regmove v0, %10 -> %20
+   regmove v0, %x10 -> %x20
+   regmove v0, %x10 -> %x20
+   regmove v0, %x20 -> %x10
+; check: regmove v0, %x10 -> %x20
+; check: regmove v0, %x10 -> %x20
     return v0
 }
 

--- a/lib/cretonne/src/flowgraph.rs
+++ b/lib/cretonne/src/flowgraph.rs
@@ -113,22 +113,26 @@ impl ControlFlowGraph {
     /// more expensive `compute`, and should be used when we know we don't need to recompute the CFG
     /// from scratch, but rather that our changes have been restricted to specific EBBs.
     pub fn recompute_ebb(&mut self, func: &Function, ebb: Ebb) {
+        debug_assert!(self.is_valid());
         self.invalidate_ebb_successors(ebb);
         self.compute_ebb(func, ebb);
     }
 
     fn add_edge(&mut self, from: BasicBlock, to: Ebb) {
+        debug_assert!(self.is_valid());
         self.data[from.0].successors.push(to);
         self.data[to].predecessors.push(from);
     }
 
     /// Get the CFG predecessor basic blocks to `ebb`.
     pub fn get_predecessors(&self, ebb: Ebb) -> &[BasicBlock] {
+        debug_assert!(self.is_valid());
         &self.data[ebb].predecessors
     }
 
     /// Get the CFG successors to `ebb`.
     pub fn get_successors(&self, ebb: Ebb) -> &[Ebb] {
+        debug_assert!(self.is_valid());
         &self.data[ebb].successors
     }
 

--- a/lib/cretonne/src/isa/mod.rs
+++ b/lib/cretonne/src/isa/mod.rs
@@ -95,6 +95,17 @@ pub fn lookup(name: &str) -> Result<Builder, LookupError> {
         "intel" => isa_builder!(intel, build_intel),
         "arm32" => isa_builder!(arm32, build_arm32),
         "arm64" => isa_builder!(arm64, build_arm64),
+        "host" => {
+            if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
+                isa_builder!(intel, build_intel)
+            } else if cfg!(target_arch = "arm") {
+                isa_builder!(intel, build_arm32)
+            } else if cfg!(target_arch = "aarch64") {
+                isa_builder!(intel, build_arm64)
+            } else {
+                Err(LookupError::Unsupported)
+            }
+        }
         _ => Err(LookupError::Unknown),
     }
 }

--- a/lib/cretonne/src/legalizer/mod.rs
+++ b/lib/cretonne/src/legalizer/mod.rs
@@ -15,6 +15,7 @@
 
 use cursor::{Cursor, FuncCursor};
 use flowgraph::ControlFlowGraph;
+use dominator_tree::DominatorTree;
 use ir::{self, InstBuilder};
 use isa::TargetIsa;
 use bitset::BitSet;
@@ -32,7 +33,17 @@ use self::heap::expand_heap_addr;
 /// - Transform any instructions that don't have a legal representation in `isa`.
 /// - Fill out `func.encodings`.
 ///
-pub fn legalize_function(func: &mut ir::Function, cfg: &mut ControlFlowGraph, isa: &TargetIsa) {
+pub fn legalize_function(
+    func: &mut ir::Function,
+    cfg: &mut ControlFlowGraph,
+    domtree: &mut DominatorTree,
+    isa: &TargetIsa,
+) {
+    // Legalization invalidates the domtree by mutating the CFG.
+    domtree.clear();
+
+    cfg.ensure(&func);
+
     boundary::legalize_signatures(func, isa);
 
     func.encodings.resize(func.dfg.num_insts());

--- a/lib/cretonne/src/verifier/mod.rs
+++ b/lib/cretonne/src/verifier/mod.rs
@@ -812,6 +812,10 @@ impl<'a> Verifier<'a> {
     }
 
     fn cfg_integrity(&self, cfg: &ControlFlowGraph) -> Result {
+        if !cfg.is_valid() {
+            return Ok(());
+        }
+
         let mut expected_succs = BTreeSet::<Ebb>::new();
         let mut got_succs = BTreeSet::<Ebb>::new();
         let mut expected_preds = BTreeSet::<Inst>::new();

--- a/lib/reader/src/error.rs
+++ b/lib/reader/src/error.rs
@@ -8,7 +8,8 @@ use std::result;
 /// The location of a `Token` or `Error`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Location {
-    /// Line number, starting from 1.
+    /// Line number. Command-line arguments are line 0 and source file
+    /// lines start from 1.
     pub line_number: usize,
 }
 
@@ -23,7 +24,11 @@ pub struct Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}: {}", self.location.line_number, self.message)
+        if self.location.line_number == 0 {
+            write!(f, "command-line arguments: {}", self.message)
+        } else {
+            write!(f, "{}: {}", self.location.line_number, self.message)
+        }
     }
 }
 

--- a/lib/reader/src/lib.rs
+++ b/lib/reader/src/lib.rs
@@ -11,7 +11,7 @@ pub use error::{Location, Result, Error};
 pub use parser::{parse_functions, parse_test};
 pub use testcommand::{TestCommand, TestOption};
 pub use testfile::{TestFile, Details, Comment};
-pub use isaspec::IsaSpec;
+pub use isaspec::{IsaSpec, parse_options};
 pub use sourcemap::SourceMap;
 
 mod error;

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -1010,9 +1010,7 @@ impl<'a> Parser<'a> {
                             .map(ArgumentLoc::Reg)
                             .ok_or(self.error("invalid register name"))
                     } else {
-                        // We are unable to parse the register without a TargetISA, so we quietly
-                        // ignore it.
-                        Ok(ArgumentLoc::Unassigned)
+                        err!(self.loc, "argument location requires exactly one isa")
                     }
                 }
                 Some(Token::Integer(_)) => {
@@ -1491,8 +1489,7 @@ impl<'a> Parser<'a> {
                         .map(ValueLoc::Reg)
                         .ok_or(self.error("invalid register value location"))
                 } else {
-                    // For convenience we ignore value locations when no unique ISA is specified
-                    Ok(ValueLoc::Unassigned)
+                    err!(self.loc, "value location requires exactly one isa")
                 }
             }
             Some(Token::Minus) => {

--- a/lib/wasm/src/func_translator.rs
+++ b/lib/wasm/src/func_translator.rs
@@ -250,7 +250,6 @@ mod tests {
 
         trans.translate(&BODY, &mut ctx.func, &mut runtime).unwrap();
         dbg!("{}", ctx.func.display(None));
-        ctx.flowgraph();
         ctx.verify(None).unwrap();
     }
 
@@ -284,7 +283,6 @@ mod tests {
 
         trans.translate(&BODY, &mut ctx.func, &mut runtime).unwrap();
         dbg!("{}", ctx.func.display(None));
-        ctx.flowgraph();
         ctx.verify(None).unwrap();
     }
 
@@ -324,7 +322,6 @@ mod tests {
 
         trans.translate(&BODY, &mut ctx.func, &mut runtime).unwrap();
         dbg!("{}", ctx.func.display(None));
-        ctx.flowgraph();
         ctx.verify(None).unwrap();
     }
 }

--- a/src/cton-util.rs
+++ b/src/cton-util.rs
@@ -30,7 +30,7 @@ Usage:
     cton-util cat <file>...
     cton-util filecheck [-v] <file>
     cton-util print-cfg <file>...
-    cton-util wasm [-cvo] [--enable=<flag>]... <file>...
+    cton-util wasm [-cvo] [--set=<set>]... [--isa=<isa>] <file>...
     cton-util --help | --version
 
 Options:
@@ -38,6 +38,8 @@ Options:
     -c, --check     checks the correctness of Cretonne IL translated from WebAssembly
     -o, --optimize  runs otpimization passes on translated WebAssembly functions
     -h, --help      print this help message
+    --set=<set>     configure Cretonne settings
+    --isa=<isa>     specify the Cretonne ISA [default: host]
     --version       print the Cretonne version
 
 ";
@@ -53,7 +55,8 @@ struct Args {
     flag_check: bool,
     flag_optimize: bool,
     flag_verbose: bool,
-    flag_enable: Vec<String>,
+    flag_set: Vec<String>,
+    flag_isa: String,
 }
 
 /// A command either succeeds or fails with an error message.
@@ -85,7 +88,8 @@ fn cton_util() -> CommandResult {
             args.flag_verbose,
             args.flag_optimize,
             args.flag_check,
-            args.flag_enable,
+            args.flag_set,
+            args.flag_isa,
         )
     } else {
         // Debugging / shouldn't happen with proper command line handling above.

--- a/src/filetest/legalizer.rs
+++ b/src/filetest/legalizer.rs
@@ -40,7 +40,6 @@ impl SubTest for TestLegalizer {
         comp_ctx.func = func.into_owned();
         let isa = context.isa.expect("legalizer needs an ISA");
 
-        comp_ctx.flowgraph();
         comp_ctx.legalize(isa).map_err(|e| {
             pretty_error(&comp_ctx.func, context.isa, e)
         })?;

--- a/src/filetest/regalloc.rs
+++ b/src/filetest/regalloc.rs
@@ -44,7 +44,6 @@ impl SubTest for TestRegalloc {
         let mut comp_ctx = cretonne::Context::new();
         comp_ctx.func = func.into_owned();
 
-        comp_ctx.flowgraph();
         // TODO: Should we have an option to skip legalization?
         comp_ctx.legalize(isa).map_err(|e| {
             pretty_error(&comp_ctx.func, context.isa, e)

--- a/src/filetest/simple_gvn.rs
+++ b/src/filetest/simple_gvn.rs
@@ -33,20 +33,24 @@ impl SubTest for TestSimpleGVN {
         true
     }
 
+    fn needs_isa(&self) -> bool {
+        true
+    }
+
     fn run(&self, func: Cow<Function>, context: &Context) -> Result<()> {
+        let isa = context.isa.expect("GVN needs an ISA");
+
         // Create a compilation context, and drop in the function.
         let mut comp_ctx = cretonne::Context::new();
         comp_ctx.func = func.into_owned();
 
-        comp_ctx.simple_gvn();
-        comp_ctx.verify(context.isa).map_err(|e| {
-            pretty_error(&comp_ctx.func, context.isa, Into::into(e))
+        comp_ctx.simple_gvn(isa).map_err(|e| {
+            pretty_error(&comp_ctx.func, Some(isa), Into::into(e))
         })?;
 
         let mut text = String::new();
-        write!(&mut text, "{}", &comp_ctx.func).map_err(
-            |e| e.to_string(),
-        )?;
+        write!(&mut text, "{}", &comp_ctx.func.display(Some(isa)))
+            .map_err(|e| e.to_string())?;
         run_filecheck(&text, context)
     }
 }


### PR DESCRIPTION
This makes licm and simple_gvn tests require a target ISA. Those passes don't inherently require a target ISA, though in any realistic use case they'll have one, and this allows them to have access to the contained Flags.

This also moves the responsibility for asking for cfg and domtree computations the code that needs them, to reduce the number of places that implicitly know about pass dependencies.

And it adds a more complete way to specify flags and isa to cton-wasm via the command-line.
