### PR TITLE
Make passes assert their dependencies consistently.

### DIFF
--- a/lib/cretonne/src/context.rs
+++ b/lib/cretonne/src/context.rs
@@ -65,9 +65,9 @@ impl Context {
     pub fn compile(&mut self, isa: &TargetIsa) -> Result<CodeOffset, CtonError> {
         self.verify_if(isa)?;
 
-        self.cfg.compute(&self.func);
+        self.compute_cfg();
         self.legalize(isa)?;
-        self.domtree.compute(&self.func, &self.cfg);
+        self.compute_domtree();
         self.regalloc(isa)?;
         self.prologue_epilogue(isa)?;
         self.relax_branches(isa)
@@ -112,10 +112,29 @@ impl Context {
         self.verify_if(isa)
     }
 
-    /// Recompute the control flow graph and dominator tree.
+    /// Compute the control flow graph.
+    pub fn compute_cfg(&mut self) {
+        self.cfg.compute(&self.func)
+    }
+
+    /// Compute dominator tree.
+    pub fn compute_domtree(&mut self) {
+        self.domtree.compute(&self.func, &self.cfg)
+    }
+
+    /// Compute the loop analysis.
+    pub fn compute_loop_analysis(&mut self) {
+        self.loop_analysis.compute(
+            &self.func,
+            &self.cfg,
+            &self.domtree,
+        )
+    }
+
+    /// Compute the control flow graph and dominator tree.
     pub fn flowgraph(&mut self) {
-        self.cfg.compute(&self.func);
-        self.domtree.compute(&self.func, &self.cfg);
+        self.compute_cfg();
+        self.compute_domtree()
     }
 
     /// Perform simple GVN on the function.

--- a/lib/cretonne/src/dominator_tree.rs
+++ b/lib/cretonne/src/dominator_tree.rs
@@ -219,10 +219,7 @@ impl DominatorTree {
 
     /// Reset and compute a CFG post-order and dominator tree.
     pub fn compute(&mut self, func: &Function, cfg: &ControlFlowGraph) {
-        debug_assert!(
-            cfg.is_valid(),
-            "DominatorTree computation requires a computed CFG"
-        );
+        debug_assert!(cfg.is_valid());
         self.compute_postorder(func, cfg);
         self.compute_domtree(func, cfg);
         self.valid = true;

--- a/lib/cretonne/src/dominator_tree.rs
+++ b/lib/cretonne/src/dominator_tree.rs
@@ -212,7 +212,6 @@ impl DominatorTree {
 
     /// Allocate and compute a dominator tree.
     pub fn with_function(func: &Function, cfg: &ControlFlowGraph) -> DominatorTree {
-        debug_assert!(cfg.is_valid());
         let mut domtree = DominatorTree::new();
         domtree.compute(func, cfg);
         domtree

--- a/lib/cretonne/src/dominator_tree.rs
+++ b/lib/cretonne/src/dominator_tree.rs
@@ -235,6 +235,7 @@ impl DominatorTree {
         self.nodes.clear();
         self.postorder.clear();
         assert!(self.stack.is_empty());
+        self.valid = false;
     }
 
     /// Check if the dominator tree is in a valid state.

--- a/lib/cretonne/src/legalizer/mod.rs
+++ b/lib/cretonne/src/legalizer/mod.rs
@@ -33,6 +33,8 @@ use self::heap::expand_heap_addr;
 /// - Fill out `func.encodings`.
 ///
 pub fn legalize_function(func: &mut ir::Function, cfg: &mut ControlFlowGraph, isa: &TargetIsa) {
+    debug_assert!(cfg.is_valid());
+
     boundary::legalize_signatures(func, isa);
 
     func.encodings.resize(func.dfg.num_insts());

--- a/lib/cretonne/src/licm.rs
+++ b/lib/cretonne/src/licm.rs
@@ -16,9 +16,13 @@ pub fn do_licm(
     domtree: &mut DominatorTree,
     loop_analysis: &mut LoopAnalysis,
 ) {
-    cfg.ensure(func);
-    domtree.ensure(func, cfg);
-    loop_analysis.ensure(func, cfg, domtree);
+    debug_assert!(cfg.is_valid(), "LICM requires the CFG to be computed");
+    debug_assert!(domtree.is_valid(), "LICM requires a computed DominatorTree");
+    debug_assert!(
+        loop_analysis.is_valid(),
+        "LICM requires a computed LoopAnalysis"
+    );
+
     for lp in loop_analysis.loops() {
         // For each loop that we want to optimize we determine the set of loop-invariant
         // instructions

--- a/lib/cretonne/src/licm.rs
+++ b/lib/cretonne/src/licm.rs
@@ -16,12 +16,9 @@ pub fn do_licm(
     domtree: &mut DominatorTree,
     loop_analysis: &mut LoopAnalysis,
 ) {
-    debug_assert!(cfg.is_valid(), "LICM requires the CFG to be computed");
-    debug_assert!(domtree.is_valid(), "LICM requires a computed DominatorTree");
-    debug_assert!(
-        loop_analysis.is_valid(),
-        "LICM requires a computed LoopAnalysis"
-    );
+    debug_assert!(cfg.is_valid());
+    debug_assert!(domtree.is_valid());
+    debug_assert!(loop_analysis.is_valid());
 
     for lp in loop_analysis.loops() {
         // For each loop that we want to optimize we determine the set of loop-invariant

--- a/lib/cretonne/src/loop_analysis.rs
+++ b/lib/cretonne/src/loop_analysis.rs
@@ -18,9 +18,9 @@ entity_impl!(Loop, "loop");
 /// Loops are referenced by the Loop object, and for each loop you can access its header EBB,
 /// its eventual parent in the loop tree and all the EBB belonging to the loop.
 pub struct LoopAnalysis {
-    valid: bool,
     loops: PrimaryMap<Loop, LoopData>,
     ebb_loop_map: EntityMap<Ebb, PackedOption<Loop>>,
+    valid: bool,
 }
 
 struct LoopData {
@@ -115,12 +115,13 @@ impl LoopAnalysis {
         self.valid
     }
 
-    /// Conveneince function to call `compute` if `compute` hasn't been called
-    /// since the last `clear()`.
-    pub fn ensure(&mut self, func: &Function, cfg: &ControlFlowGraph, domtree: &DominatorTree) {
-        if !self.is_valid() {
-            self.compute(func, cfg, domtree)
-        }
+    /// Clear all the data structures contanted in the loop analysis. This will leave the
+    /// analysis in a similar state to a context returned by `new()` except that allocated
+    /// memory be retained.
+    pub fn clear(&mut self) {
+        self.loops.clear();
+        self.ebb_loop_map.clear();
+        self.valid = false;
     }
 
     // Traverses the CFG in reverse postorder and create a loop object for every EBB having a

--- a/lib/cretonne/src/regalloc/context.rs
+++ b/lib/cretonne/src/regalloc/context.rs
@@ -60,10 +60,7 @@ impl Context {
         cfg: &ControlFlowGraph,
         domtree: &mut DominatorTree,
     ) -> CtonResult {
-        debug_assert!(
-            domtree.is_valid(),
-            "regalloc requires a computed DominatorTree"
-        );
+        debug_assert!(domtree.is_valid());
 
         // `Liveness` and `Coloring` are self-clearing.
         self.virtregs.clear();

--- a/lib/cretonne/src/regalloc/context.rs
+++ b/lib/cretonne/src/regalloc/context.rs
@@ -60,8 +60,10 @@ impl Context {
         cfg: &ControlFlowGraph,
         domtree: &mut DominatorTree,
     ) -> CtonResult {
-        // Ensure that a valid domtree exists.
-        domtree.ensure(func, cfg);
+        debug_assert!(
+            domtree.is_valid(),
+            "regalloc requires a computed DominatorTree"
+        );
 
         // `Liveness` and `Coloring` are self-clearing.
         self.virtregs.clear();

--- a/lib/cretonne/src/simple_gvn.rs
+++ b/lib/cretonne/src/simple_gvn.rs
@@ -14,11 +14,8 @@ fn trivially_unsafe_for_gvn(opcode: Opcode) -> bool {
 /// Perform simple GVN on `func`.
 ///
 pub fn do_simple_gvn(func: &mut Function, cfg: &mut ControlFlowGraph, domtree: &mut DominatorTree) {
-    debug_assert!(cfg.is_valid(), "Simple-GVN requires the CFG to be computed");
-    debug_assert!(
-        domtree.is_valid(),
-        "Simple-GVN requires a computed DominatorTree"
-    );
+    debug_assert!(cfg.is_valid());
+    debug_assert!(domtree.is_valid());
 
     let mut visible_values: HashMap<(InstructionData, Type), Inst> = HashMap::new();
 

--- a/lib/cretonne/src/simple_gvn.rs
+++ b/lib/cretonne/src/simple_gvn.rs
@@ -14,8 +14,11 @@ fn trivially_unsafe_for_gvn(opcode: Opcode) -> bool {
 /// Perform simple GVN on `func`.
 ///
 pub fn do_simple_gvn(func: &mut Function, cfg: &mut ControlFlowGraph, domtree: &mut DominatorTree) {
-    cfg.ensure(func);
-    domtree.ensure(func, cfg);
+    debug_assert!(cfg.is_valid(), "Simple-GVN requires the CFG to be computed");
+    debug_assert!(
+        domtree.is_valid(),
+        "Simple-GVN requires a computed DominatorTree"
+    );
 
     let mut visible_values: HashMap<(InstructionData, Type), Inst> = HashMap::new();
 

--- a/lib/cretonne/src/verifier/mod.rs
+++ b/lib/cretonne/src/verifier/mod.rs
@@ -134,7 +134,9 @@ pub fn verify_context(
     isa: Option<&TargetIsa>,
 ) -> Result {
     let verifier = Verifier::new(func, isa);
-    verifier.cfg_integrity(cfg)?;
+    if cfg.is_valid() {
+        verifier.cfg_integrity(cfg)?;
+    }
     if domtree.is_valid() {
         verifier.domtree_integrity(domtree)?;
     }

--- a/lib/wasm/src/func_translator.rs
+++ b/lib/wasm/src/func_translator.rs
@@ -250,7 +250,6 @@ mod tests {
 
         trans.translate(&BODY, &mut ctx.func, &mut runtime).unwrap();
         dbg!("{}", ctx.func.display(None));
-        ctx.flowgraph();
         ctx.verify(None).unwrap();
     }
 
@@ -284,7 +283,6 @@ mod tests {
 
         trans.translate(&BODY, &mut ctx.func, &mut runtime).unwrap();
         dbg!("{}", ctx.func.display(None));
-        ctx.flowgraph();
         ctx.verify(None).unwrap();
     }
 
@@ -324,7 +322,6 @@ mod tests {
 
         trans.translate(&BODY, &mut ctx.func, &mut runtime).unwrap();
         dbg!("{}", ctx.func.display(None));
-        ctx.flowgraph();
         ctx.verify(None).unwrap();
     }
 }

--- a/src/filetest/legalizer.rs
+++ b/src/filetest/legalizer.rs
@@ -40,7 +40,7 @@ impl SubTest for TestLegalizer {
         comp_ctx.func = func.into_owned();
         let isa = context.isa.expect("legalizer needs an ISA");
 
-        comp_ctx.flowgraph();
+        comp_ctx.cfg.compute(&comp_ctx.func);
         comp_ctx.legalize(isa).map_err(|e| {
             pretty_error(&comp_ctx.func, context.isa, e)
         })?;

--- a/src/filetest/legalizer.rs
+++ b/src/filetest/legalizer.rs
@@ -40,7 +40,7 @@ impl SubTest for TestLegalizer {
         comp_ctx.func = func.into_owned();
         let isa = context.isa.expect("legalizer needs an ISA");
 
-        comp_ctx.cfg.compute(&comp_ctx.func);
+        comp_ctx.compute_cfg();
         comp_ctx.legalize(isa).map_err(|e| {
             pretty_error(&comp_ctx.func, context.isa, e)
         })?;

--- a/src/filetest/licm.rs
+++ b/src/filetest/licm.rs
@@ -38,6 +38,12 @@ impl SubTest for TestLICM {
         let mut comp_ctx = cretonne::Context::new();
         comp_ctx.func = func.into_owned();
 
+        comp_ctx.flowgraph();
+        comp_ctx.loop_analysis.compute(
+            &comp_ctx.func,
+            &comp_ctx.cfg,
+            &comp_ctx.domtree,
+        );
         comp_ctx.licm();
         comp_ctx.verify(context.isa).map_err(|e| {
             pretty_error(&comp_ctx.func, context.isa, Into::into(e))

--- a/src/filetest/licm.rs
+++ b/src/filetest/licm.rs
@@ -39,11 +39,7 @@ impl SubTest for TestLICM {
         comp_ctx.func = func.into_owned();
 
         comp_ctx.flowgraph();
-        comp_ctx.loop_analysis.compute(
-            &comp_ctx.func,
-            &comp_ctx.cfg,
-            &comp_ctx.domtree,
-        );
+        comp_ctx.compute_loop_analysis();
         comp_ctx.licm();
         comp_ctx.verify(context.isa).map_err(|e| {
             pretty_error(&comp_ctx.func, context.isa, Into::into(e))

--- a/src/filetest/regalloc.rs
+++ b/src/filetest/regalloc.rs
@@ -44,11 +44,12 @@ impl SubTest for TestRegalloc {
         let mut comp_ctx = cretonne::Context::new();
         comp_ctx.func = func.into_owned();
 
-        comp_ctx.flowgraph();
+        comp_ctx.cfg.compute(&comp_ctx.func);
         // TODO: Should we have an option to skip legalization?
         comp_ctx.legalize(isa).map_err(|e| {
             pretty_error(&comp_ctx.func, context.isa, e)
         })?;
+        comp_ctx.domtree.compute(&comp_ctx.func, &comp_ctx.cfg);
         comp_ctx.regalloc(isa).map_err(|e| {
             pretty_error(&comp_ctx.func, context.isa, e)
         })?;

--- a/src/filetest/regalloc.rs
+++ b/src/filetest/regalloc.rs
@@ -44,12 +44,12 @@ impl SubTest for TestRegalloc {
         let mut comp_ctx = cretonne::Context::new();
         comp_ctx.func = func.into_owned();
 
-        comp_ctx.cfg.compute(&comp_ctx.func);
+        comp_ctx.compute_cfg();
         // TODO: Should we have an option to skip legalization?
         comp_ctx.legalize(isa).map_err(|e| {
             pretty_error(&comp_ctx.func, context.isa, e)
         })?;
-        comp_ctx.domtree.compute(&comp_ctx.func, &comp_ctx.cfg);
+        comp_ctx.compute_domtree();
         comp_ctx.regalloc(isa).map_err(|e| {
             pretty_error(&comp_ctx.func, context.isa, e)
         })?;

--- a/src/filetest/simple_gvn.rs
+++ b/src/filetest/simple_gvn.rs
@@ -38,6 +38,7 @@ impl SubTest for TestSimpleGVN {
         let mut comp_ctx = cretonne::Context::new();
         comp_ctx.func = func.into_owned();
 
+        comp_ctx.flowgraph();
         comp_ctx.simple_gvn();
         comp_ctx.verify(context.isa).map_err(|e| {
             pretty_error(&comp_ctx.func, context.isa, Into::into(e))

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -159,11 +159,7 @@ fn handle_module(
                 pretty_verifier_error(&context.func, None, err)
             })?;
             context.flowgraph();
-            context.loop_analysis.compute(
-                &context.func,
-                &context.cfg,
-                &context.domtree,
-            );
+            context.compute_loop_analysis();
             context.licm();
             context.verify(None).map_err(|err| {
                 pretty_verifier_error(&context.func, None, err)

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -158,6 +158,12 @@ fn handle_module(
             context.verify(None).map_err(|err| {
                 pretty_verifier_error(&context.func, None, err)
             })?;
+            context.flowgraph();
+            context.loop_analysis.compute(
+                &context.func,
+                &context.cfg,
+                &context.domtree,
+            );
             context.licm();
             context.verify(None).map_err(|err| {
                 pretty_verifier_error(&context.func, None, err)


### PR DESCRIPTION
This avoids ambiguity about whose responsibility it is to run
to compute cfg, domtree, and loop_analysis data.