### PR TITLE
Add settings and isa command-line options to cton-util wasm.

### DIFF
--- a/lib/reader/src/error.rs
+++ b/lib/reader/src/error.rs
@@ -8,7 +8,8 @@ use std::result;
 /// The location of a `Token` or `Error`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Location {
-    /// Line number, starting from 1.
+    /// Line number. Command-line arguments are line 0 and source file
+    /// lines start from 1.
     pub line_number: usize,
 }
 
@@ -23,7 +24,11 @@ pub struct Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}: {}", self.location.line_number, self.message)
+        if self.location.line_number == 0 {
+            write!(f, "command-line arguments: {}", self.message)
+        } else {
+            write!(f, "{}: {}", self.location.line_number, self.message)
+        }
     }
 }
 

--- a/lib/reader/src/lib.rs
+++ b/lib/reader/src/lib.rs
@@ -11,7 +11,7 @@ pub use error::{Location, Result, Error};
 pub use parser::{parse_functions, parse_test};
 pub use testcommand::{TestCommand, TestOption};
 pub use testfile::{TestFile, Details, Comment};
-pub use isaspec::IsaSpec;
+pub use isaspec::{IsaSpec, parse_options};
 pub use sourcemap::SourceMap;
 
 mod error;

--- a/src/cton-util.rs
+++ b/src/cton-util.rs
@@ -30,7 +30,7 @@ Usage:
     cton-util cat <file>...
     cton-util filecheck [-v] <file>
     cton-util print-cfg <file>...
-    cton-util wasm [-cvo] [--enable=<flag>]... <file>...
+    cton-util wasm [-cvo] [--set <set>]... [--isa <isa>] <file>...
     cton-util --help | --version
 
 Options:
@@ -38,6 +38,8 @@ Options:
     -c, --check     checks the correctness of Cretonne IL translated from WebAssembly
     -o, --optimize  runs otpimization passes on translated WebAssembly functions
     -h, --help      print this help message
+    --set=<set>     configure Cretonne settings
+    --isa=<isa>     specify the Cretonne ISA
     --version       print the Cretonne version
 
 ";
@@ -53,7 +55,8 @@ struct Args {
     flag_check: bool,
     flag_optimize: bool,
     flag_verbose: bool,
-    flag_enable: Vec<String>,
+    flag_set: Vec<String>,
+    flag_isa: String,
 }
 
 /// A command either succeeds or fails with an error message.
@@ -85,7 +88,8 @@ fn cton_util() -> CommandResult {
             args.flag_verbose,
             args.flag_optimize,
             args.flag_check,
-            args.flag_enable,
+            args.flag_set,
+            args.flag_isa,
         )
     } else {
         // Debugging / shouldn't happen with proper command line handling above.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -11,7 +11,6 @@ use cretonne::Context;
 use cretonne::verifier;
 use cretonne::settings;
 use cretonne::isa::{self, TargetIsa};
-use std::borrow::Borrow;
 use std::fs::File;
 use std::error::Error;
 use std::io;
@@ -86,7 +85,7 @@ pub fn run(
             path.to_path_buf(),
             name,
             &flags,
-            isa.borrow(),
+            &*isa,
         )?;
     }
     Ok(())

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -5,10 +5,13 @@
 //! and tables, then emitting the translated code with hardcoded addresses to memory.
 
 use cton_wasm::{translate_module, DummyRuntime, WasmRuntime};
+use cton_reader::{parse_options, Location};
 use std::path::PathBuf;
 use cretonne::Context;
 use cretonne::verifier;
-use cretonne::settings::{self, Configurable};
+use cretonne::settings;
+use cretonne::isa::{self, TargetIsa};
+use std::borrow::Borrow;
 use std::fs::File;
 use std::error::Error;
 use std::io;
@@ -50,15 +53,31 @@ pub fn run(
     flag_verbose: bool,
     flag_optimize: bool,
     flag_check: bool,
-    flag_enable: Vec<String>,
+    flag_set: Vec<String>,
+    flag_isa: String,
 ) -> Result<(), String> {
     let mut flag_builder = settings::builder();
-    for enable in flag_enable {
-        flag_builder.enable(&enable).map_err(|_| {
-            format!("unrecognized flag: {}", enable)
-        })?;
-    }
+    parse_options(
+        flag_set.iter().map(|x| x.as_str()),
+        &mut flag_builder,
+        &Location { line_number: 0 },
+    ).map_err(|err| err.to_string())?;
     let flags = settings::Flags::new(&flag_builder);
+
+    let mut words = flag_isa.trim().split_whitespace();
+    // Look for `isa foo`.
+    let isa_name = match words.next() {
+        None => return Err(String::from("expected ISA name")),
+        Some(w) => w,
+    };
+    let isa_builder = match isa::lookup(isa_name) {
+        Err(isa::LookupError::Unknown) => return Err(format!("unknown ISA '{}'", isa_name)),
+        Err(isa::LookupError::Unsupported) => {
+            return Err(format!("support for ISA '{}' not enabled", isa_name))
+        }
+        Ok(b) => b,
+    };
+    let isa = isa_builder.finish(settings::Flags::new(&flag_builder));
 
     for filename in files {
         let path = Path::new(&filename);
@@ -70,6 +89,7 @@ pub fn run(
             path.to_path_buf(),
             name,
             &flags,
+            isa.borrow(),
         )?;
     }
     Ok(())
@@ -82,6 +102,7 @@ fn handle_module(
     path: PathBuf,
     name: String,
     flags: &settings::Flags,
+    isa: &TargetIsa,
 ) -> Result<(), String> {
     let mut terminal = term::stdout().unwrap();
     terminal.fg(term::color::YELLOW).unwrap();
@@ -140,8 +161,8 @@ fn handle_module(
         vprint!(flag_verbose, "Checking...   ");
         terminal.reset().unwrap();
         for func in &translation.functions {
-            verifier::verify_function(func, None).map_err(|err| {
-                pretty_verifier_error(func, None, err)
+            verifier::verify_function(func, Some(isa)).map_err(|err| {
+                pretty_verifier_error(func, Some(isa), err)
             })?;
         }
         terminal.fg(term::color::GREEN).unwrap();
@@ -155,16 +176,16 @@ fn handle_module(
         for func in &translation.functions {
             let mut context = Context::new();
             context.func = func.clone();
-            context.verify(None).map_err(|err| {
-                pretty_verifier_error(&context.func, None, err)
+            context.verify(Some(isa)).map_err(|err| {
+                pretty_verifier_error(&context.func, Some(isa), err)
             })?;
             context.licm();
-            context.verify(None).map_err(|err| {
-                pretty_verifier_error(&context.func, None, err)
+            context.verify(Some(isa)).map_err(|err| {
+                pretty_verifier_error(&context.func, Some(isa), err)
             })?;
             context.simple_gvn();
-            context.verify(None).map_err(|err| {
-                pretty_verifier_error(&context.func, None, err)
+            context.verify(Some(isa)).map_err(|err| {
+                pretty_verifier_error(&context.func, Some(isa), err)
             })?;
         }
         terminal.fg(term::color::GREEN).unwrap();

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -70,13 +70,10 @@ pub fn run(
         None => return Err(String::from("expected ISA name")),
         Some(w) => w,
     };
-    let isa_builder = match isa::lookup(isa_name) {
-        Err(isa::LookupError::Unknown) => return Err(format!("unknown ISA '{}'", isa_name)),
-        Err(isa::LookupError::Unsupported) => {
-            return Err(format!("support for ISA '{}' not enabled", isa_name))
-        }
-        Ok(b) => b,
-    };
+    let isa_builder = isa::lookup(isa_name).map_err(|err| match err {
+        isa::LookupError::Unknown => format!("unknown ISA '{}'", isa_name),
+        isa::LookupError::Unsupported => format!("support for ISA '{}' not enabled", isa_name),
+    })?;
     let isa = isa_builder.finish(settings::Flags::new(&flag_builder));
 
     for filename in files {


### PR DESCRIPTION
This implements the full parsing for `set` and `isa` commands, following the [feedback](https://github.com/stoklund/cretonne/pull/155#issuecomment-329295426).