### PR TITLE
Do a full compile in 'cton-util wasm'.

### DIFF
--- a/lib/cretonne/src/context.rs
+++ b/lib/cretonne/src/context.rs
@@ -18,7 +18,7 @@ use isa::TargetIsa;
 use legalize_function;
 use regalloc;
 use result::{CtonError, CtonResult};
-use settings::FlagsOrIsa;
+use settings::{FlagsOrIsa, OptLevel};
 use verifier;
 use simple_gvn::do_simple_gvn;
 use licm::do_licm;
@@ -68,6 +68,12 @@ impl Context {
 
         self.compute_cfg();
         self.legalize(isa)?;
+        if isa.flags().opt_level() == OptLevel::Best {
+            self.compute_domtree();
+            self.compute_loop_analysis();
+            self.licm(isa)?;
+            self.simple_gvn(isa)?;
+        }
         self.compute_domtree();
         self.regalloc(isa)?;
         self.prologue_epilogue(isa)?;

--- a/src/cton-util.rs
+++ b/src/cton-util.rs
@@ -30,13 +30,16 @@ Usage:
     cton-util cat <file>...
     cton-util filecheck [-v] <file>
     cton-util print-cfg <file>...
-    cton-util wasm [-cvo] [--set <set>]... [--isa <isa>] <file>...
+    cton-util wasm [-ctvp] [--set <set>]... [--isa <isa>] <file>...
     cton-util --help | --version
 
 Options:
     -v, --verbose   be more verbose
-    -c, --check     checks the correctness of Cretonne IL translated from WebAssembly
-    -o, --optimize  runs otpimization passes on translated WebAssembly functions
+    -t, --just-decode
+                    just decode WebAssembly to Cretonne IL
+    -c, --check-translation
+                    just checks the correctness of Cretonne IL translated from WebAssembly
+    -p, --print     print the resulting Cretonne IL
     -h, --help      print this help message
     --set=<set>     configure Cretonne settings
     --isa=<isa>     specify the Cretonne ISA
@@ -52,8 +55,9 @@ struct Args {
     cmd_print_cfg: bool,
     cmd_wasm: bool,
     arg_file: Vec<String>,
-    flag_check: bool,
-    flag_optimize: bool,
+    flag_just_decode: bool,
+    flag_check_translation: bool,
+    flag_print: bool,
     flag_verbose: bool,
     flag_set: Vec<String>,
     flag_isa: String,
@@ -86,8 +90,9 @@ fn cton_util() -> CommandResult {
         wasm::run(
             args.arg_file,
             args.flag_verbose,
-            args.flag_optimize,
-            args.flag_check,
+            args.flag_just_decode,
+            args.flag_check_translation,
+            args.flag_print,
             args.flag_set,
             args.flag_isa,
         )

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -8,7 +8,6 @@ use cton_wasm::{translate_module, DummyRuntime, WasmRuntime};
 use cton_reader::{parse_options, Location};
 use std::path::PathBuf;
 use cretonne::Context;
-use cretonne::verifier;
 use cretonne::settings::{self, FlagsOrIsa};
 use cretonne::isa::{self, TargetIsa};
 use std::fs::File;
@@ -54,8 +53,9 @@ enum OwnedFlagsOrIsa {
 pub fn run(
     files: Vec<String>,
     flag_verbose: bool,
-    flag_optimize: bool,
-    flag_check: bool,
+    flag_just_decode: bool,
+    flag_check_translation: bool,
+    flag_print: bool,
     flag_set: Vec<String>,
     flag_isa: String,
 ) -> Result<(), String> {
@@ -87,8 +87,9 @@ pub fn run(
         let name = String::from(path.as_os_str().to_string_lossy());
         handle_module(
             flag_verbose,
-            flag_optimize,
-            flag_check,
+            flag_just_decode,
+            flag_check_translation,
+            flag_print,
             path.to_path_buf(),
             name,
             &fisa,
@@ -99,8 +100,9 @@ pub fn run(
 
 fn handle_module(
     flag_verbose: bool,
-    flag_optimize: bool,
-    flag_check: bool,
+    flag_just_decode: bool,
+    flag_check_translation: bool,
+    flag_print: bool,
     path: PathBuf,
     name: String,
     fisa: &FlagsOrIsa,
@@ -157,41 +159,38 @@ fn handle_module(
     terminal.fg(term::color::GREEN).unwrap();
     vprintln!(flag_verbose, " ok");
     terminal.reset().unwrap();
-    if flag_check {
-        terminal.fg(term::color::MAGENTA).unwrap();
-        vprint!(flag_verbose, "Checking...   ");
-        terminal.reset().unwrap();
-        for func in &translation.functions {
-            verifier::verify_function(func, *fisa).map_err(|err| {
-                pretty_verifier_error(func, fisa.isa, err)
-            })?;
-        }
-        terminal.fg(term::color::GREEN).unwrap();
-        vprintln!(flag_verbose, " ok");
-        terminal.reset().unwrap();
+    if flag_just_decode {
+        return Ok(());
     }
-    if flag_optimize {
-        terminal.fg(term::color::MAGENTA).unwrap();
-        vprint!(flag_verbose, "Optimizing... ");
-        terminal.reset().unwrap();
-        for func in &translation.functions {
-            let mut context = Context::new();
-            context.func = func.clone();
+    terminal.fg(term::color::MAGENTA).unwrap();
+    if flag_check_translation {
+        vprint!(flag_verbose, "Checking... ");
+    } else {
+        vprint!(flag_verbose, "Compiling... ");
+    }
+    terminal.reset().unwrap();
+    for func in &translation.functions {
+        let mut context = Context::new();
+        context.func = func.clone();
+        if flag_check_translation {
             context.verify(*fisa).map_err(|err| {
                 pretty_verifier_error(&context.func, fisa.isa, err)
             })?;
-            context.flowgraph();
-            context.compute_loop_analysis();
-            context.licm(*fisa).map_err(|err| {
-                pretty_error(&context.func, fisa.isa, err)
-            })?;
-            context.simple_gvn(*fisa).map_err(|err| {
-                pretty_error(&context.func, fisa.isa, err)
-            })?;
+            continue;
         }
-        terminal.fg(term::color::GREEN).unwrap();
-        vprintln!(flag_verbose, " ok");
-        terminal.reset().unwrap();
+        if let Some(isa) = fisa.isa {
+            context.compile(isa).map_err(|err| {
+                pretty_error(&context.func, fisa.isa, err)
+            })?;
+        } else {
+            return Err(String::from("compilation requires a target isa"));
+        }
+        if flag_print {
+            println!("{}", context.func.display(fisa.isa));
+        }
     }
+    terminal.fg(term::color::GREEN).unwrap();
+    vprintln!(flag_verbose, " ok");
+    terminal.reset().unwrap();
     Ok(())
 }


### PR DESCRIPTION
This removes the `optimize` option, as one can do that with
`--set`, eg. `--set opt_level=fastest`. And it adds an option to
print the compilation output.

And, it enables simple_gvn and licm for opt_level=fastest in Context.