### PR TITLE
Clarify undefined behavior and notrap.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,6 @@ target-independent intermediate language into executable machine code.
 Cretonne is designed to be a code generator for WebAssembly with these design
 goals:
 
-No undefined behavior
-    Cretonne does not have a `nasal demons clause <http://www.catb.org/jargon/html/N/nasal-demons.html>`_, and it won't generate code
-    with unexpected behavior if invariants are broken.
 Portable semantics
     As far as possible, Cretonne's input language has well-defined semantics
     that are the same on all target architectures. The semantics are usually
@@ -28,8 +25,8 @@ Portable semantics
 Fast sandbox verification
     Cretonne's input language has a safe subset for sandboxed code. No advanced
     analysis is required to verify memory safety as long as only the safe
-    instructions are used. The safe instruction set is expressive enough to
-    implement WebAssembly.
+    subset is used. The safe subset is expressive enough to implement
+    WebAssembly.
 Scalable performance
     Cretonne can be configured to generate code as quickly as possible, or it
     can generate very good code at the cost of slower compile times.

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -441,7 +441,7 @@ When the address is the result of a :inst:`heap_addr`, :inst:`stack_addr`, or
 :inst:`global_addr` with sufficient size to cover the access given its size
 and offset, and there are no intervening memory reallocations, they are *safe*,
 and either succeed or reliably *trap*, depending on whether the computed address
-is *mapped* or not.
+is :term:`mapped` or not.
 
 When these conditions are not met, the behavior of these instructions is
 undefined.
@@ -461,13 +461,13 @@ optimizations.
 ======= =========================================
 Flag    Description
 ======= =========================================
-notrap  Address is known to be *mapped*.
+notrap  Address is known to be :term:`mapped`.
 aligned Trapping allowed for misaligned accesses.
 ======= =========================================
 
 Normal memory accesses are defined to either :ref:`succeed or trap <memory>`
-depending on whether the accesed memory is *mapped*. When the ``notrap`` flag
-is set, the behavior is undefined if the memory is not *mapped*.
+depending on whether the accesed memory is :term:`mapped`. When the ``notrap``
+flag is set, the behavior is undefined if the memory is not mapped.
 
 Loads and stores are *misaligned* if the resultant address is not a multiple of
 the expected alignment. By default, misaligned loads and stores are allowed,
@@ -597,9 +597,9 @@ architecture.
 
 A heap appears as three consecutive ranges of address space:
 
-1. The *mapped pages* are the usable memory range in the heap. Loads and stores
-   to this range won't trap. A heap may have a minimum guaranteed size which
-   means that some mapped pages are always present.
+1. The *mapped pages* are the :term:`mapped` memory range in the heap. Loads and
+   stores to this range won't trap. A heap may have a minimum guaranteed size
+   which means that some mapped pages are always present.
 2. The *unmapped pages* is a possibly empty range of address space that may be
    mapped in the future when the heap is grown.
 3. The *guard pages* is a range of address space that is guaranteed to cause a
@@ -619,11 +619,11 @@ Static heaps
 ~~~~~~~~~~~~
 
 A *static heap* starts out with all the address space it will ever need, so it
-never moves to a different address. At the base address is a number of mapped
-pages corresponding to the heap's current size. Then follows a number of
-unmapped pages where the heap can grow up to its maximum size. After the
-unmapped pages follow the guard pages which are also guaranteed to generate a
-trap when accessed.
+never moves to a different address. At the base address is a number of
+:term:`mapped` pages corresponding to the heap's current size. Then follows a
+number of unmapped pages where the heap can grow up to its maximum size. After
+the unmapped pages follow the guard pages which are also guaranteed to generate
+a trap when accessed.
 
 .. inst:: H = static Base, min MinBytes, bound BoundBytes, guard GuardBytes
 
@@ -1087,6 +1087,10 @@ Glossary
         Cretonne uses to represent a program internally are called the
         intermediate representation. Cretonne's IR can be converted to text
         losslessly.
+
+    mapped
+        Mapping memory is memory in which loads and stores have defined
+        behavior and succeed without trapping.
 
     stack slot
         A fixed size memory allocation in the current function's activation

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -440,8 +440,8 @@ accessing memory, as well as :ref:`extending loads and truncating stores
 When the address is the result of a :inst:`heap_addr`, :inst:`stack_addr`, or
 :inst:`global_addr` with sufficient size to cover the access given its size
 and offset, and there are no intervening memory reallocations, they are *safe*,
-and either succeed or reliably *trap*, depending on whether the computed address
-is :term:`mapped` or not.
+and either succeed or reliably :term:`trap`, depending on whether the computed
+address is :term:`mapped` or not.
 
 When these conditions are not met, the behavior of these instructions is
 undefined.
@@ -472,7 +472,7 @@ flag is set, the behavior is undefined if the memory is not mapped.
 Loads and stores are *misaligned* if the resultant address is not a multiple of
 the expected alignment. By default, misaligned loads and stores are allowed,
 but when the ``aligned`` flag is set, a misaligned memory access is allowed to
-trap.
+:term:`trap`.
 
 Local variables
 ---------------
@@ -579,9 +579,9 @@ in, and all accesses are bounds checked. Cretonne models this through the
 concept of *heaps*.
 
 A heap is declared in the function preamble and can be accessed with the
-:inst:`heap_addr` instruction that traps on out-of-bounds accesses or returns a
-pointer that is guaranteed to trap. Heap addresses can be smaller than the
-native pointer size, for example unsigned :type:`i32` offsets on a 64-bit
+:inst:`heap_addr` instruction that :term:`traps` on out-of-bounds accesses or
+returns a pointer that is guaranteed to trap. Heap addresses can be smaller than
+the native pointer size, for example unsigned :type:`i32` offsets on a 64-bit
 architecture.
 
 .. digraph:: static
@@ -1090,7 +1090,7 @@ Glossary
 
     mapped
         Mapping memory is memory in which loads and stores have defined
-        behavior and succeed without trapping.
+        behavior and succeed without :term:`trapping`.
 
     stack slot
         A fixed size memory allocation in the current function's activation
@@ -1104,3 +1104,10 @@ Glossary
         The basic terminator instructions are :inst:`br`, :inst:`return`, and
         :inst:`trap`. Conditional branches and instructions that trap
         conditionally are not terminator instructions.
+
+    trap
+    traps
+    trapping
+        Terminates execution of the current thread. The specific behavior after
+        a trap depends on the underlying OS. A common behavior is be delivery
+        of a signal.

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -461,8 +461,13 @@ optimizations.
 ======= =========================================
 Flag    Description
 ======= =========================================
+notrap  Address is known to be *mapped*.
 aligned Trapping allowed for misaligned accesses.
 ======= =========================================
+
+Normal memory accesses are defined to either :ref:`succeed or trap <memory>`
+depending on whether the accesed memory is *mapped*. When the ``notrap`` flag
+is set, the behavior is undefined if the memory is not *mapped*.
 
 Loads and stores are *misaligned* if the resultant address is not a multiple of
 the expected alignment. By default, misaligned loads and stores are allowed,

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -1124,5 +1124,6 @@ Glossary
     traps
     trapping
         Terminates execution of the current thread. The specific behavior after
-        a trap depends on the underlying OS. A common behavior is be delivery
-        of a signal.
+        a trap depends on the underlying OS. For example, a common behavior is
+        delivery of a signal, with the specific signal depending on the event
+        that triggered it.

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -440,11 +440,6 @@ accessing memory, as well as :ref:`extending loads and truncating stores
 If the memory at the given addresss is not :term:`addressable`, the behavior is
 undefined.
 
-If the address is the result of a :inst:`heap_addr`, :inst:`stack_addr`, or
-:inst:`global_addr`, and either the access extends outside the size given for
-the address computation, or there has been an intervening memory reallocation
-since the address computation, the behavior is undefined.
-
 .. autoinst:: load
 .. autoinst:: store
 

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -929,10 +929,8 @@ In addition to the normal :inst:`load` and :inst:`store` instructions, Cretonne
 provides extending loads and truncation stores for 8, 16, and 32-bit memory
 accesses.
 
-As with :ref:`normal loads and stores <memory>`, these instructions are
-:term:`safe` and have defined behavior (either succeeding or reliably trapping)
-only if the address operand is the result of a satisfactory :inst:`heap_addr`,
-:inst:`stack_addr`, or :inst:`global_addr`.
+These instructions succeed, trap, or have undefined behavior, under the same
+conditions as :ref:`normal loads and stores <memory>`.
 
 .. autoinst:: uload8
 .. autoinst:: sload8

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -1019,14 +1019,15 @@ Glossary
     addressable
         Memory in which loads and stores have defined behavior. They either
         succeed or :term:`trap`, depending on whether the memory is
-        :term:`accessible`. Heaps, globals, and the stack may contain both
-        addressable and unaddressable regions. There may also be additional
-        regions of addressable memory not explicitly declared.
+        :term:`accessible`.
 
     accessible
         :term:`Addressable` memory in which loads and stores always succeed
         without :term:`trapping`, except where specified otherwise (eg. with the
-        `aligned` flag).
+        `aligned` flag). Heaps, globals, and the stack may contain accessible,
+        merely addressable, and outright unaddressable regions. There may also
+        be additional regions of addressable and/or accessible memory not
+        explicitly declared.
 
     basic block
         A maximal sequence of instructions that can only be entered from the

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -478,7 +478,8 @@ Local variables
 One set of restricted memory operations access the current function's stack
 frame. The stack frame is divided into fixed-size stack slots that are
 allocated in the :term:`function preamble`. Stack slots are not typed, they
-simply represent a contiguous sequence of bytes in the stack frame.
+simply represent a contiguous sequence of :term:`accessible` bytes in the stack
+frame.
 
 .. inst:: SS = local Bytes, Flags...
 
@@ -515,12 +516,12 @@ instructions before instruction selection::
 Global variables
 ----------------
 
-A *global variable* is an object in memory whose address is not known at
-compile time. The address is computed at runtime by :inst:`global_addr`,
-possibly using information provided by the linker via relocations. There are
-multiple kinds of global variables using different methods for determining
-their address. Cretonne does not track the type or even the size of global
-variables, they are just pointers to non-stack memory.
+A *global variable* is an :term:`accessible` object in memory whose address is
+not known at compile time. The address is computed at runtime by
+:inst:`global_addr`, possibly using information provided by the linker via
+relocations. There are multiple kinds of global variables using different
+methods for determining their address. Cretonne does not track the type or even
+the size of global variables, they are just pointers to non-stack memory.
 
 When Cretonne is generating code for a virtual machine environment, globals can
 be used to access data structures in the VM's runtime. This requires functions

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -437,10 +437,14 @@ Cretonne provides fully general :inst:`load` and :inst:`store` instructions for
 accessing memory, as well as :ref:`extending loads and truncating stores
 <extload-truncstore>`.
 
-By themselves, these instructions are *unsafe*. They perform raw unsandboxed
-memory accesses. They are safe if the address operand is the result of a
-sufficient :inst:`heap_addr`, :inst:`stack_addr`, or :inst:`global_addr`
-with no intervening memory reallocation.
+When the address is the result of a :inst:`heap_addr`, :inst:`stack_addr`, or
+:inst:`global_addr` with sufficient size to cover the access given its size
+and offset, and there are no intervening memory reallocations, they are *safe*,
+and either succeed or reliably *trap*, depending on whether the computed address
+is *mapped* or not.
+
+When these conditions are not met, the behavior of these instructions is
+undefined.
 
 .. autoinst:: load
 .. autoinst:: store
@@ -920,10 +924,10 @@ In addition to the normal :inst:`load` and :inst:`store` instructions, Cretonne
 provides extending loads and truncation stores for 8, 16, and 32-bit memory
 accesses.
 
-As with :ref:`normal loads and stores <memory>`, these instructions are *unsafe*
-unless the address operand is the result of a sufficient :inst:`heap_addr`,
-:inst:`stack_addr`, or :inst:`global_addr` with no intervening memory
-reallocation.
+As with :ref:`normal loads and stores <memory>`, these instructions are *safe*
+and have defined behavior (either succeeding or reliably trapping) only if the
+address operand is the result of a satisfactory :inst:`heap_addr`,
+:inst:`stack_addr`, or :inst:`global_addr`.
 
 .. autoinst:: uload8
 .. autoinst:: sload8

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -439,9 +439,9 @@ accessing memory, as well as :ref:`extending loads and truncating stores
 
 When the address is the result of a :inst:`heap_addr`, :inst:`stack_addr`, or
 :inst:`global_addr` with sufficient size to cover the access given its size
-and offset, and there are no intervening memory reallocations, they are *safe*,
-and either succeed or reliably :term:`trap`, depending on whether the computed
-address is :term:`mapped` or not.
+and offset, and there are no intervening memory reallocations, they are
+:term:`safe`, and either succeed or reliably :term:`trap`, depending on whether
+the computed address is :term:`mapped` or not.
 
 When these conditions are not met, the behavior of these instructions is
 undefined.
@@ -501,8 +501,8 @@ about because stack slots and offsets are fixed at compile time. For example,
 the alignment of these stack memory accesses can be inferred from the offsets
 and stack slot alignments.
 
-It can be necessary to escape from the safety of the restricted instructions by
-taking the address of a stack slot.
+It can be necessary to escape from the :term:`safety` of the restricted
+instructions by taking the address of a stack slot.
 
 .. autoinst:: stack_addr
 
@@ -929,9 +929,9 @@ In addition to the normal :inst:`load` and :inst:`store` instructions, Cretonne
 provides extending loads and truncation stores for 8, 16, and 32-bit memory
 accesses.
 
-As with :ref:`normal loads and stores <memory>`, these instructions are *safe*
-and have defined behavior (either succeeding or reliably trapping) only if the
-address operand is the result of a satisfactory :inst:`heap_addr`,
+As with :ref:`normal loads and stores <memory>`, these instructions are
+:term:`safe` and have defined behavior (either succeeding or reliably trapping)
+only if the address operand is the result of a satisfactory :inst:`heap_addr`,
 :inst:`stack_addr`, or :inst:`global_addr`.
 
 .. autoinst:: uload8
@@ -1091,6 +1091,15 @@ Glossary
     mapped
         Mapping memory is memory in which loads and stores have defined
         behavior and succeed without :term:`trapping`.
+
+    safe
+    safety
+        Execution of exclusively defined behavior. Safe programs cannot
+        read, write, or execute memory outside of heaps, globals, stack
+        regions, and functions that have been explicitly provided to them. In
+        some instances, defined behavior can be nondeterministic, where the
+        specific behavior may vary among a bounded set of possibilities.
+        Execution of undefined behavior is unsafe.
 
     stack slot
         A fixed size memory allocation in the current function's activation

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -428,17 +428,25 @@ Indirect function calls use a signature declared in the preamble.
 .. autoinst:: call_indirect
 .. autoinst:: func_addr
 
+.. _memory:
 
 Memory
 ======
 
 Cretonne provides fully general :inst:`load` and :inst:`store` instructions for
 accessing memory, as well as :ref:`extending loads and truncating stores
-<extload-truncstore>`. There are also more restricted operations for accessing
-specific types of memory objects.
+<extload-truncstore>`.
+
+By themselves, these instructions are *unsafe*. They perform raw unsandboxed
+memory accesses. They are safe if the address operand is the result of a
+sufficient :inst:`heap_addr`, :inst:`stack_addr`, or :inst:`global_addr`
+with no intervening memory reallocation.
 
 .. autoinst:: load
 .. autoinst:: store
+
+There are also more restricted operations for accessing specific types of memory
+objects.
 
 Memory operation flags
 ----------------------
@@ -449,15 +457,8 @@ optimizations.
 ======= =========================================
 Flag    Description
 ======= =========================================
-notrap  Trapping is not required.
 aligned Trapping allowed for misaligned accesses.
 ======= =========================================
-
-Trapping is part of the semantics of memory accesses. The operating system may
-have configured parts of the address space to cause a trap when read and/or
-written, and Cretonne's memory instructions respect that. When the ``notrap``
-flat is set, the trapping behavior is optional. This allows the optimizer to
-delete loads whose results are not used.
 
 Loads and stores are *misaligned* if the resultant address is not a multiple of
 the expected alignment. By default, misaligned loads and stores are allowed,
@@ -918,6 +919,11 @@ only write the low bits of an integer register are common.
 In addition to the normal :inst:`load` and :inst:`store` instructions, Cretonne
 provides extending loads and truncation stores for 8, 16, and 32-bit memory
 accesses.
+
+As with :ref:`normal loads and stores <memory>`, these instructions are *unsafe*
+unless the address operand is the result of a sufficient :inst:`heap_addr`,
+:inst:`stack_addr`, or :inst:`global_addr` with no intervening memory
+reallocation.
 
 .. autoinst:: uload8
 .. autoinst:: sload8

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -437,8 +437,9 @@ Cretonne provides fully general :inst:`load` and :inst:`store` instructions for
 accessing memory, as well as :ref:`extending loads and truncating stores
 <extload-truncstore>`.
 
-If the memory at the given addresss is not :term:`addressable`, the behavior is
-undefined.
+If the memory at the given addresss is not :term:`addressable`, the behavior of
+these instructions is undefined. If it is addressable but not
+:term:`accessible`, they :term:`trap`.
 
 .. autoinst:: load
 .. autoinst:: store
@@ -604,7 +605,8 @@ A heap appears as three consecutive ranges of address space:
 
 The *heap bound* is the total size of the mapped and unmapped pages. This is
 the bound that :inst:`heap_addr` checks against. Memory accesses inside the
-heap bounds can trap if they hit a page which is not :term:`accessible`.
+heap bounds can trap if they hit an unmapped page (which is not
+:term:`accessible`).
 
 .. autoinst:: heap_addr
 
@@ -1015,10 +1017,11 @@ Glossary
 .. glossary::
 
     addressable
-        Memory in which loads and stores have defined behavior and either
-        succeed or :term:`trap`. Heaps, globals, and the stack may contain
-        both addressable and unaddressable regions. There may also be
-        additional regions of addressable memory not explicitly declared.
+        Memory in which loads and stores have defined behavior. They either
+        succeed or :term:`trap`, depending on whether the memory is
+        :term:`accessible`. Heaps, globals, and the stack may contain both
+        addressable and unaddressable regions. There may also be additional
+        regions of addressable memory not explicitly declared.
 
     accessible
         :term:`Addressable` memory in which loads and stores always succeed

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -1026,7 +1026,8 @@ Glossary
 
     accessible
         :term:`Addressable` memory in which loads and stores always succeed
-        without :term:`trapping`.
+        without :term:`trapping`, except where specified otherwise (eg. with the
+        `aligned` flag).
 
     basic block
         A maximal sequence of instructions that can only be entered from the


### PR DESCRIPTION
This PR proposes that load/store/etc. become plain native unchecked memory accesses, without reliable trapping, and with full UB on OOB.

Verifiable safety may be had by using a heap_addr/stack_addr/global_addr immediately before every raw access. Bounds-check elimination optimizations may be performed by using a single heap_addr/stack_addr/global_addr for multiple accesses. Load DCE and DSE can be performed on normal load/store/etc. in the usual ways.
