### PR TITLE
Avoid dangling references to block params when sealing an unreachable block.

### DIFF
--- a/docs/example.cton
+++ b/docs/example.cton
@@ -4,7 +4,7 @@ function %average(i32, i32) -> f32 native {
     ss1 = local 8            ; Stack slot for ``sum``.
 
 ebb1(v1: i32, v2: i32):
-    v3 = f64const 0x0.0
+    v3 = f64const.f64 0x0.0
     stack_store v3, ss1
     brz v2, ebb3                  ; Handle count == 0.
     v4 = iconst.i32 0
@@ -28,6 +28,6 @@ ebb2(v5: i32):
     return v17
 
 ebb3:
-    v100 = f32const +NaN
+    v100 = f32const.f32 +NaN
     return v100
 }

--- a/filetests/cfg/loop.cton
+++ b/filetests/cfg/loop.cton
@@ -8,7 +8,7 @@ function %nonsense(i32, i32) -> f32 {
 ; check: label="{ebb0 | <$(BRZ=$I)>brz ebb2 | <$(JUMP=$I)>jump ebb1}"]
 
 ebb0(v1: i32, v2: i32):
-    v3 = f64const 0x0.0
+    v3 = f64const.f64 0x0.0
     brz v2, ebb2            ; unordered: ebb0:$BRZ -> ebb2
     v4 = iconst.i32 0
     jump ebb1(v4)           ; unordered: ebb0:$JUMP -> ebb1
@@ -16,20 +16,20 @@ ebb0(v1: i32, v2: i32):
 ebb1(v5: i32):
     v6 = imul_imm v5, 4
     v7 = iadd v1, v6
-    v8 = f32const 0.0
-    v9 = f32const 0.0
-    v10 = f32const 0.0
+    v8 = f32const.f32 0.0
+    v9 = f32const.f32 0.0
+    v10 = f32const.f32 0.0
     v11 = fadd v9, v10
     v12 = iadd_imm v5, 1
     v13 = icmp ult v12, v2
     brnz v13, ebb1(v12)     ; unordered: ebb1:inst12 -> ebb1
-    v14 = f64const 0.0
-    v15 = f64const 0.0
+    v14 = f64const.f64 0.0
+    v15 = f64const.f64 0.0
     v16 = fdiv v14, v15
-    v17 = f32const 0.0
+    v17 = f32const.f32 0.0
     return v17
 
 ebb2:
-    v100 = f32const 0.0
+    v100 = f32const.f32 0.0
     return v100
 }

--- a/filetests/isa/intel/legalize-custom.cton
+++ b/filetests/isa/intel/legalize-custom.cton
@@ -55,7 +55,7 @@ ebb0(v1: i32):
 
 function %f32const() -> f32 {
 ebb0:
-    v1 = f32const 0x1.0p1
+    v1 = f32const.f32 0x1.0p1
     ; check: $(tmp=$V) = iconst.i32
     ; check: $v1 = bitcast.f32 $tmp
     return v1
@@ -63,7 +63,7 @@ ebb0:
 
 function %f64const() -> f64 {
 ebb0:
-    v1 = f64const 0x1.0p1
+    v1 = f64const.f64 0x1.0p1
     ; check: $(tmp=$V) = iconst.i64
     ; check: $v1 = bitcast.f64 $tmp
     return v1

--- a/filetests/parser/call.cton
+++ b/filetests/parser/call.cton
@@ -13,13 +13,13 @@ ebb1:
 function %r1() -> i32, f32 spiderwasm {
 ebb1:
     v1 = iconst.i32 3
-    v2 = f32const 0.0
+    v2 = f32const.f32 0.0
     return v1, v2
 }
 ; sameln: function %r1() -> i32, f32 spiderwasm {
 ; nextln: ebb0:
 ; nextln:     $v1 = iconst.i32 3
-; nextln:     $v2 = f32const 0.0
+; nextln:     $v2 = f32const.f32 0.0
 ; nextln:     return $v1, $v2
 ; nextln: }
 

--- a/filetests/parser/flags.cton
+++ b/filetests/parser/flags.cton
@@ -26,7 +26,7 @@ ebb2:
 
 function %fflags(f32) {
 ebb0(v0: f32):
-    v1 = f32const 0x34.0p0
+    v1 = f32const.f32 0x34.0p0
     v2 = ffcmp v0, v1
     brff eq v2, ebb1
     brff ord v2, ebb2

--- a/filetests/parser/rewrite.cton
+++ b/filetests/parser/rewrite.cton
@@ -12,13 +12,13 @@ test cat
 function %defs() {
 ebb100(v20: i32):
     v1000 = iconst.i32x8 5
-    v9200 = f64const 0x4.0p0
+    v9200 = f64const.f64 0x4.0p0
     trap user4
 }
 ; sameln: function %defs() native {
 ; nextln: $ebb100($v20: i32):
 ; nextln:     $v1000 = iconst.i32x8 5
-; nextln:     $v9200 = f64const 0x1.0000000000000p2
+; nextln:     $v9200 = f64const.f64 0x1.0000000000000p2
 ; nextln:     trap user4
 ; nextln: }
 

--- a/filetests/verifier/type_check.cton
+++ b/filetests/verifier/type_check.cton
@@ -52,7 +52,7 @@ function %fn_call_too_many_args() {
     fn5 = function %best_fn()
     ebb0:
         v0 = iconst.i64 56
-        v1 = f32const 0.0
+        v1 = f32const.f32 0.0
         call fn5(v0, v1) ; error: mismatched argument count, got 2, expected 0
         return
 }

--- a/filetests/wasm/f32-arith.cton
+++ b/filetests/wasm/f32-arith.cton
@@ -11,7 +11,7 @@ isa intel haswell
 
 function %f32_const() -> f32 {
 ebb0:
-    v1 = f32const 0x3.0
+    v1 = f32const.f32 0x3.0
     return v1
 }
 

--- a/filetests/wasm/f64-arith.cton
+++ b/filetests/wasm/f64-arith.cton
@@ -8,7 +8,7 @@ isa intel haswell
 
 function %f64_const() -> f64 {
 ebb0:
-    v1 = f64const 0x3.0
+    v1 = f64const.f64 0x3.0
     return v1
 }
 

--- a/lib/cretonne/meta/base/instructions.py
+++ b/lib/cretonne/meta/base/instructions.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 from cdsl.operands import Operand, VARIABLE_ARGS
 from cdsl.typevar import TypeVar
 from cdsl.instructions import Instruction, InstructionGroup
-from base.types import f32, f64, b1, iflags, fflags
+from base.types import b1, iflags, fflags
 from base.immediates import imm64, uimm8, uimm32, ieee32, ieee64, offset32
 from base.immediates import boolean, intcc, floatcc, memflags, regunit
 from base.immediates import trapcode
@@ -21,6 +21,10 @@ GROUP = InstructionGroup("base", "Shared base instruction set")
 Int = TypeVar('Int', 'A scalar or vector integer type', ints=True, simd=True)
 Bool = TypeVar('Bool', 'A scalar or vector boolean type',
                bools=True, simd=True)
+F32 = TypeVar('F32', 'A scalar or vector f32 type',
+        floats=(32), simd=True)
+F64 = TypeVar('F64', 'A scalar or vector f64 type',
+        floats=(64), simd=True)
 iB = TypeVar('iB', 'A scalar integer type', ints=True)
 iAddr = TypeVar('iAddr', 'An integer address type', ints=(32, 64))
 Testable = TypeVar(
@@ -429,7 +433,7 @@ iconst = Instruction(
         ins=N, outs=a)
 
 N = Operand('N', ieee32)
-a = Operand('a', f32, doc='A constant integer scalar or vector value')
+a = Operand('a', F32, doc='A constant f32 scalar or vector value')
 f32const = Instruction(
         'f32const', r"""
         Floating point constant.
@@ -440,7 +444,7 @@ f32const = Instruction(
         ins=N, outs=a)
 
 N = Operand('N', ieee64)
-a = Operand('a', f64, doc='A constant integer scalar or vector value')
+a = Operand('a', F64, doc='A constant f64 scalar or vector value')
 f64const = Instruction(
         'f64const', r"""
         Floating point constant.

--- a/lib/wasm/src/code_translator.rs
+++ b/lib/wasm/src/code_translator.rs
@@ -479,10 +479,10 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         Operator::I32Const { value } => state.push1(builder.ins().iconst(I32, value as i64)),
         Operator::I64Const { value } => state.push1(builder.ins().iconst(I64, value)),
         Operator::F32Const { value } => {
-            state.push1(builder.ins().f32const(f32_translation(value)));
+            state.push1(builder.ins().f32const(F32, f32_translation(value)));
         }
         Operator::F64Const { value } => {
-            state.push1(builder.ins().f64const(f64_translation(value)));
+            state.push1(builder.ins().f64const(F64, f64_translation(value)));
         }
         /******************************* Unary Operators *************************************/
         Operator::I32Clz => {

--- a/lib/wasm/src/func_translator.rs
+++ b/lib/wasm/src/func_translator.rs
@@ -163,8 +163,18 @@ fn declare_locals(
     let zeroval = match wasm_type {
         I32 => builder.ins().iconst(ir::types::I32, 0),
         I64 => builder.ins().iconst(ir::types::I64, 0),
-        F32 => builder.ins().f32const(ir::immediates::Ieee32::with_bits(0)),
-        F64 => builder.ins().f64const(ir::immediates::Ieee64::with_bits(0)),
+        F32 => {
+            builder.ins().f32const(
+                ir::types::F32,
+                ir::immediates::Ieee32::with_bits(0),
+            )
+        }
+        F64 => {
+            builder.ins().f64const(
+                ir::types::F64,
+                ir::immediates::Ieee64::with_bits(0),
+            )
+        }
         _ => return Err(CtonError::InvalidInput),
     };
 


### PR DESCRIPTION
This started out as a fairly ordinary bug fix, but the fix exposed another problem: `f32const` and `f64const` are documented as working for either scalar or vector, but they currently only support scalar. The naive fix is to give them an explicit type parameter, which is what this patch currently does, though it does makes things more verbose. And it's an API change.

Another option would be to just remove support for SIMD values from ssa.rs for now.