### PR TITLE
Add support for symbolic global variables.

### DIFF
--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -563,6 +563,16 @@ runtime data structures.
                  variable.
     :result GV: Global variable.
 
+.. inst:: GV = globalsym name
+
+    Declare a global variable at a symbolic address.
+
+    The address of GV is symbolic and will be assigned a relocation, so that
+    it can be resolved by a later linking phase.
+
+    :arg name: External name.
+    :result GV: Global variable.
+
 .. autoinst:: global_addr
 
 

--- a/filetests/isa/intel/allones_funcaddrs32.cton
+++ b/filetests/isa/intel/allones_funcaddrs32.cton
@@ -1,0 +1,25 @@
+; binary emission of 32-bit code.
+test binemit
+set is_compressed
+set allones_funcaddrs
+isa intel haswell
+
+; The binary encodings can be verified with the command:
+;
+;   sed -ne 's/^ *; asm: *//p' filetests/isa/intel/allones_funcaddrs32.cton | llvm-mc -show-encoding -triple=i386
+;
+
+; Tests from binary32.cton affected by allones_funcaddrs.
+function %I32() {
+    fn0 = function %foo()
+    sig0 = ()
+
+ebb0:
+
+    ; asm: movl $-1, %ecx
+    [-,%rcx]            v400 = func_addr.i32 fn0        ; bin: b9 Abs4(fn0) ffffffff
+    ; asm: movl $-1, %esi
+    [-,%rsi]            v401 = func_addr.i32 fn0        ; bin: be Abs4(fn0) ffffffff
+
+    return                                              ; bin: c3
+}

--- a/filetests/isa/intel/allones_funcaddrs64.cton
+++ b/filetests/isa/intel/allones_funcaddrs64.cton
@@ -1,0 +1,28 @@
+; binary emission of 64-bit code.
+test binemit
+set is_64bit
+set is_compressed
+set allones_funcaddrs
+isa intel haswell
+
+; The binary encodings can be verified with the command:
+;
+;   sed -ne 's/^ *; asm: *//p' filetests/isa/intel/allones_funcaddrs64.cton | llvm-mc -show-encoding -triple=x86_64
+;
+
+; Tests from binary64.cton affected by allones_funcaddrs.
+function %I64() {
+    fn0 = function %foo()
+    sig0 = ()
+
+ebb0:
+
+    ; asm: movabsq $-1, %rcx
+    [-,%rcx]            v400 = func_addr.i64 fn0        ; bin: 48 b9 Abs8(fn0) ffffffffffffffff
+    ; asm: movabsq $-1, %rsi
+    [-,%rsi]            v401 = func_addr.i64 fn0        ; bin: 48 be Abs8(fn0) ffffffffffffffff
+    ; asm: movabsq $-1, %r10
+    [-,%r10]            v402 = func_addr.i64 fn0        ; bin: 49 ba Abs8(fn0) ffffffffffffffff
+
+    return                                              ; bin: c3
+}

--- a/filetests/isa/intel/binary32.cton
+++ b/filetests/isa/intel/binary32.cton
@@ -12,6 +12,8 @@ function %I32() {
     fn0 = function %foo()
     sig0 = ()
 
+    gv0 = globalsym %some_gv
+
     ss0 = incoming_arg 8, offset 0
     ss1 = incoming_arg 1024, offset -1024
     ss2 = incoming_arg 1024, offset -2048
@@ -342,15 +344,20 @@ ebb0:
     ; asm: call foo
     call fn0()                                  ; bin: e8 PCRel4(fn0) 00000000
 
-    ; asm: movl $-1, %ecx
+    ; asm: movl $0, %ecx
     [-,%rcx]            v400 = func_addr.i32 fn0        ; bin: b9 Abs4(fn0) 00000000
-    ; asm: movl $-1, %esi
+    ; asm: movl $0, %esi
     [-,%rsi]            v401 = func_addr.i32 fn0        ; bin: be Abs4(fn0) 00000000
 
     ; asm: call *%ecx
     call_indirect sig0, v400()                  ; bin: ff d1
     ; asm: call *%esi
     call_indirect sig0, v401()                  ; bin: ff d6
+
+    ; asm: movl $0, %ecx
+    [-,%rcx]            v450 = globalsym_addr.i32 gv0    ; bin: b9 Abs4(gv0) 00000000
+    ; asm: movl $0, %esi
+    [-,%rsi]            v451 = globalsym_addr.i32 gv0    ; bin: be Abs4(gv0) 00000000
 
     ; Spill / Fill.
 

--- a/filetests/isa/intel/binary32.cton
+++ b/filetests/isa/intel/binary32.cton
@@ -343,9 +343,9 @@ ebb0:
     call fn0()                                  ; bin: e8 PCRel4(fn0) 00000000
 
     ; asm: movl $-1, %ecx
-    [-,%rcx]            v400 = func_addr.i32 fn0        ; bin: b9 Abs4(fn0) ffffffff
+    [-,%rcx]            v400 = func_addr.i32 fn0        ; bin: b9 Abs4(fn0) 00000000
     ; asm: movl $-1, %esi
-    [-,%rsi]            v401 = func_addr.i32 fn0        ; bin: be Abs4(fn0) ffffffff
+    [-,%rsi]            v401 = func_addr.i32 fn0        ; bin: be Abs4(fn0) 00000000
 
     ; asm: call *%ecx
     call_indirect sig0, v400()                  ; bin: ff d1

--- a/filetests/isa/intel/binary64.cton
+++ b/filetests/isa/intel/binary64.cton
@@ -14,6 +14,8 @@ function %I64() {
     fn0 = function %foo()
     sig0 = ()
 
+    gv0 = globalsym %some_gv
+
     ; Use incoming_arg stack slots because they won't be relocated by the frame
     ; layout.
     ss0 = incoming_arg 8, offset 0
@@ -429,11 +431,11 @@ ebb0:
     ; asm: call foo
     call fn0()                                  ; bin: e8 PCRel4(fn0) 00000000
 
-    ; asm: movabsq $-1, %rcx
+    ; asm: movabsq $0, %rcx
     [-,%rcx]            v400 = func_addr.i64 fn0        ; bin: 48 b9 Abs8(fn0) 0000000000000000
-    ; asm: movabsq $-1, %rsi
+    ; asm: movabsq $0, %rsi
     [-,%rsi]            v401 = func_addr.i64 fn0        ; bin: 48 be Abs8(fn0) 0000000000000000
-    ; asm: movabsq $-1, %r10
+    ; asm: movabsq $0, %r10
     [-,%r10]            v402 = func_addr.i64 fn0        ; bin: 49 ba Abs8(fn0) 0000000000000000
 
     ; asm: call *%rcx
@@ -442,6 +444,13 @@ ebb0:
     call_indirect sig0, v401()                  ; bin: ff d6
     ; asm: call *%r10
     call_indirect sig0, v402()                  ; bin: 41 ff d2
+
+    ; asm: movabsq $-1, %rcx
+    [-,%rcx]            v450 = globalsym_addr.i64 gv0    ; bin: 48 b9 Abs8(gv0) 0000000000000000
+    ; asm: movabsq $-1, %rsi
+    [-,%rsi]            v451 = globalsym_addr.i64 gv0    ; bin: 48 be Abs8(gv0) 0000000000000000
+    ; asm: movabsq $-1, %r10
+    [-,%r10]            v452 = globalsym_addr.i64 gv0    ; bin: 49 ba Abs8(gv0) 0000000000000000
 
     ; Spill / Fill.
 

--- a/filetests/isa/intel/binary64.cton
+++ b/filetests/isa/intel/binary64.cton
@@ -430,11 +430,11 @@ ebb0:
     call fn0()                                  ; bin: e8 PCRel4(fn0) 00000000
 
     ; asm: movabsq $-1, %rcx
-    [-,%rcx]            v400 = func_addr.i64 fn0        ; bin: 48 b9 Abs8(fn0) ffffffffffffffff
+    [-,%rcx]            v400 = func_addr.i64 fn0        ; bin: 48 b9 Abs8(fn0) 0000000000000000
     ; asm: movabsq $-1, %rsi
-    [-,%rsi]            v401 = func_addr.i64 fn0        ; bin: 48 be Abs8(fn0) ffffffffffffffff
+    [-,%rsi]            v401 = func_addr.i64 fn0        ; bin: 48 be Abs8(fn0) 0000000000000000
     ; asm: movabsq $-1, %r10
-    [-,%r10]            v402 = func_addr.i64 fn0        ; bin: 49 ba Abs8(fn0) ffffffffffffffff
+    [-,%r10]            v402 = func_addr.i64 fn0        ; bin: 49 ba Abs8(fn0) 0000000000000000
 
     ; asm: call *%rcx
     call_indirect sig0, v400()                  ; bin: ff d1

--- a/filetests/isa/intel/legalize-memory.cton
+++ b/filetests/isa/intel/legalize-memory.cton
@@ -29,6 +29,19 @@ ebb1(v1: i64):
     ; check: return $v2
 }
 
+function %sym() -> i64 {
+    gv0 = globalsym %something
+    gv1 = globalsym #d0bad180d0b5d182d0bed0bd
+
+ebb1:
+    v0 = global_addr.i64 gv0
+    ; check: $v0 = globalsym_addr.i64 gv0
+    v1 = global_addr.i64 gv1
+    ; check: $v1 = globalsym_addr.i64 gv1
+    v2 = bxor v0, v1
+    return v2
+}
+
 ; SpiderMonkey VM-style static 4+2 GB heap.
 ; This eliminates bounds checks completely for offsets < 2GB.
 function %staticheap_sm64(i32, i64 vmctx) -> f32 spiderwasm {

--- a/filetests/parser/memory.cton
+++ b/filetests/parser/memory.cton
@@ -36,6 +36,20 @@ ebb0:
     return v1
 }
 
+function %sym() -> i32 {
+    gv0 = globalsym %something
+    ; check: $gv0 = globalsym %something
+    gv1 = globalsym #d0bad180d0b5d182d0bed0bd
+    ; check: $gv1 = globalsym #d0bad180d0b5d182d0bed0bd
+ebb0:
+    v0 = global_addr.i32 gv0
+    ; check: $v0 = global_addr.i32 $gv0
+    v1 = global_addr.i32 gv1
+    ; check: $v1 = global_addr.i32 $gv1
+    v2 = bxor v0, v1
+    return v2
+}
+
 ; Declare static heaps.
 function %sheap(i32) -> i64 {
     heap1 = static reserved_reg, min 0x1_0000, bound 0x1_0000_0000, guard 0x8000_0000

--- a/lib/cretonne/meta/base/instructions.py
+++ b/lib/cretonne/meta/base/instructions.py
@@ -389,6 +389,14 @@ global_addr = Instruction(
         """,
         ins=GV, outs=addr)
 
+# A specialized form of global_addr instructions that only handles
+# symbolic names.
+globalsym_addr = Instruction(
+        'globalsym_addr', r"""
+        Compute the address of global variable GV, which is a symbolic name.
+        """,
+        ins=GV, outs=addr)
+
 #
 # WebAssembly bounds-checked heap accesses.
 #

--- a/lib/cretonne/meta/base/settings.py
+++ b/lib/cretonne/meta/base/settings.py
@@ -69,5 +69,13 @@ spiderwasm_prologue_words = NumSetting(
         pushed return address on Intel ISAs.
         """)
 
+#
+# BaldrMonkey requires that not-yet-relocated function addresses be encoded
+# as all-ones bitpatterns.
+#
+allones_funcaddrs = BoolSetting(
+        """
+        Emit not-yet-relocated function addresses as all-ones bit patterns.
+        """)
 
 group.close(globals())

--- a/lib/cretonne/meta/isa/intel/encodings.py
+++ b/lib/cretonne/meta/isa/intel/encodings.py
@@ -2,7 +2,7 @@
 Intel Encodings.
 """
 from __future__ import absolute_import
-from cdsl.predicates import IsUnsignedInt
+from cdsl.predicates import IsUnsignedInt, Not
 from base import instructions as base
 from base.formats import UnaryImm
 from .defs import I32, I64
@@ -11,6 +11,7 @@ from . import settings as cfg
 from . import instructions as x86
 from .legalize import intel_expand
 from base.legalize import narrow, expand
+from base.settings import allones_funcaddrs
 from .settings import use_sse41
 
 try:
@@ -260,8 +261,15 @@ enc_both(base.regspill.f64, r.frsp32, 0x66, 0x0f, 0xd6)
 # Function addresses.
 #
 
-I32.enc(base.func_addr.i32, *r.fnaddr4(0xb8))
-I64.enc(base.func_addr.i64, *r.fnaddr8.rex(0xb8, w=1))
+I32.enc(base.func_addr.i32, *r.fnaddr4(0xb8),
+        isap=Not(allones_funcaddrs))
+I64.enc(base.func_addr.i64, *r.fnaddr8.rex(0xb8, w=1),
+        isap=Not(allones_funcaddrs))
+
+I32.enc(base.func_addr.i32, *r.allones_fnaddr4(0xb8),
+        isap=allones_funcaddrs)
+I64.enc(base.func_addr.i64, *r.allones_fnaddr8.rex(0xb8, w=1),
+        isap=allones_funcaddrs)
 
 #
 # Call/return

--- a/lib/cretonne/meta/isa/intel/encodings.py
+++ b/lib/cretonne/meta/isa/intel/encodings.py
@@ -272,6 +272,13 @@ I64.enc(base.func_addr.i64, *r.allones_fnaddr8.rex(0xb8, w=1),
         isap=allones_funcaddrs)
 
 #
+# Global addresses.
+#
+
+I32.enc(base.globalsym_addr.i32, *r.gvaddr4(0xb8))
+I64.enc(base.globalsym_addr.i64, *r.gvaddr8.rex(0xb8, w=1))
+
+#
 # Call/return
 #
 I32.enc(base.call, *r.call_id(0xe8))

--- a/lib/cretonne/meta/isa/intel/recipes.py
+++ b/lib/cretonne/meta/isa/intel/recipes.py
@@ -478,13 +478,31 @@ fnaddr4 = TailRecipe(
         emit='''
         PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
         sink.reloc_func(RelocKind::Abs4.into(), func_ref);
-        // Write the immediate as `!0` for the benefit of BaldrMonkey.
-        sink.put4(!0);
+        sink.put4(0);
         ''')
 
 # XX+rd iq with Abs8 function relocation.
 fnaddr8 = TailRecipe(
         'fnaddr8', FuncAddr, size=8, ins=(), outs=GPR,
+        emit='''
+        PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
+        sink.reloc_func(RelocKind::Abs8.into(), func_ref);
+        sink.put8(0);
+        ''')
+
+# Similar to fnaddr4, but writes !0 (this is used by BaldrMonkey).
+allones_fnaddr4 = TailRecipe(
+        'allones_fnaddr4', FuncAddr, size=4, ins=(), outs=GPR,
+        emit='''
+        PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
+        sink.reloc_func(RelocKind::Abs4.into(), func_ref);
+        // Write the immediate as `!0` for the benefit of BaldrMonkey.
+        sink.put4(!0);
+        ''')
+
+# Similar to fnaddr8, but writes !0 (this is used by BaldrMonkey).
+allones_fnaddr8 = TailRecipe(
+        'allones_fnaddr8', FuncAddr, size=8, ins=(), outs=GPR,
         emit='''
         PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
         sink.reloc_func(RelocKind::Abs8.into(), func_ref);

--- a/lib/cretonne/meta/isa/intel/recipes.py
+++ b/lib/cretonne/meta/isa/intel/recipes.py
@@ -9,7 +9,7 @@ from base.formats import Unary, UnaryImm, Binary, BinaryImm, MultiAry
 from base.formats import Trap, Call, IndirectCall, Store, Load
 from base.formats import IntCompare, FloatCompare, IntCond, FloatCond
 from base.formats import Jump, Branch, BranchInt, BranchFloat
-from base.formats import Ternary, FuncAddr
+from base.formats import Ternary, FuncAddr, UnaryGlobalVar
 from base.formats import RegMove, RegSpill, RegFill
 from .registers import GPR, ABCD, FPR, GPR8, FPR8, FLAG, StackGPR32, StackFPR32
 from .defs import supported_floatccs
@@ -508,6 +508,24 @@ allones_fnaddr8 = TailRecipe(
         sink.reloc_func(RelocKind::Abs8.into(), func_ref);
         // Write the immediate as `!0` for the benefit of BaldrMonkey.
         sink.put8(!0);
+        ''')
+
+# XX+rd id with Abs4 globalsym relocation.
+gvaddr4 = TailRecipe(
+        'gvaddr4', UnaryGlobalVar, size=4, ins=(), outs=GPR,
+        emit='''
+        PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
+        sink.reloc_globalsym(RelocKind::Abs4.into(), global_var);
+        sink.put4(0);
+        ''')
+
+# XX+rd iq with Abs8 globalsym relocation.
+gvaddr8 = TailRecipe(
+        'gvaddr8', UnaryGlobalVar, size=8, ins=(), outs=GPR,
+        emit='''
+        PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
+        sink.reloc_globalsym(RelocKind::Abs8.into(), global_var);
+        sink.put8(0);
         ''')
 
 #

--- a/lib/cretonne/src/binemit/memorysink.rs
+++ b/lib/cretonne/src/binemit/memorysink.rs
@@ -14,7 +14,7 @@
 //! relocations to a `RelocSink` trait object. Relocations are less frequent than the
 //! `CodeSink::put*` methods, so the performance impact of the virtual callbacks is less severe.
 
-use ir::{Ebb, FuncRef, JumpTable};
+use ir::{Ebb, FuncRef, GlobalVar, JumpTable};
 use super::{CodeSink, CodeOffset, Reloc};
 use std::ptr::write_unaligned;
 
@@ -54,6 +54,11 @@ pub trait RelocSink {
     /// Add a relocation referencing an external function at the current offset.
     fn reloc_func(&mut self, CodeOffset, Reloc, FuncRef);
 
+    /// Add a relocation referencing an external global variable symbol at the
+    /// current offset.
+    fn reloc_globalsym(&mut self, CodeOffset, Reloc, GlobalVar);
+
+    /// Add a relocation referencing a jump table.
     /// Add a relocation referencing a jump table.
     fn reloc_jt(&mut self, CodeOffset, Reloc, JumpTable);
 }
@@ -99,6 +104,11 @@ impl<'a> CodeSink for MemoryCodeSink<'a> {
     fn reloc_func(&mut self, rel: Reloc, func: FuncRef) {
         let ofs = self.offset();
         self.relocs.reloc_func(ofs, rel, func);
+    }
+
+    fn reloc_globalsym(&mut self, rel: Reloc, global: GlobalVar) {
+        let ofs = self.offset();
+        self.relocs.reloc_globalsym(ofs, rel, global);
     }
 
     fn reloc_jt(&mut self, rel: Reloc, jt: JumpTable) {

--- a/lib/cretonne/src/binemit/mod.rs
+++ b/lib/cretonne/src/binemit/mod.rs
@@ -9,7 +9,7 @@ mod memorysink;
 pub use self::relaxation::relax_branches;
 pub use self::memorysink::{MemoryCodeSink, RelocSink};
 
-use ir::{Ebb, FuncRef, JumpTable, Function, Inst};
+use ir::{Ebb, FuncRef, GlobalVar, JumpTable, Function, Inst};
 use regalloc::RegDiversions;
 
 /// Offset in bytes from the beginning of the function.
@@ -46,6 +46,10 @@ pub trait CodeSink {
 
     /// Add a relocation referencing an external function at the current offset.
     fn reloc_func(&mut self, Reloc, FuncRef);
+
+    /// Add a relocation referencing an external global variable symbol at the
+    /// current offset. This is only used for `GlobalVarData::Sym` globals.
+    fn reloc_globalsym(&mut self, Reloc, GlobalVar);
 
     /// Add a relocation referencing a jump table.
     fn reloc_jt(&mut self, Reloc, JumpTable);

--- a/lib/cretonne/src/ir/extfunc.rs
+++ b/lib/cretonne/src/ir/extfunc.rs
@@ -5,7 +5,7 @@
 //!
 //! This module declares the data types used to represent external functions and call signatures.
 
-use ir::{Type, FunctionName, SigRef, ArgumentLoc};
+use ir::{Type, ExternalName, SigRef, ArgumentLoc};
 use isa::{RegInfo, RegUnit};
 use std::cmp;
 use std::fmt;
@@ -323,7 +323,7 @@ impl FromStr for ArgumentPurpose {
 #[derive(Clone, Debug)]
 pub struct ExtFuncData {
     /// Name of the external function.
-    pub name: FunctionName,
+    pub name: ExternalName,
     /// Call signature of function.
     pub signature: SigRef,
 }

--- a/lib/cretonne/src/ir/extname.rs
+++ b/lib/cretonne/src/ir/extname.rs
@@ -1,39 +1,40 @@
-//! Function names.
+//! External names.
 //!
-//! The name of a function doesn't have any meaning to Cretonne which compiles functions
-//! independently.
+//! These are identifiers for declaring entities defined outside the current
+//! function. The name of an external declaration doesn't have any meaning to
+//! Cretonne, which compiles functions independently.
 
 use std::fmt::{self, Write};
 use std::ascii::AsciiExt;
 
-/// The name of a function can be any sequence of bytes.
+/// The name of an external can be any sequence of bytes.
 ///
-/// Function names are primarily used as keys by code using Cretonne to map
-/// from a cretonne::ir::Function to additional associated data.
+/// External names are primarily used as keys by code using Cretonne to map
+/// from a cretonne::ir::FuncRef or similar to additional associated data.
 ///
-/// Function names can also serve as a primitive testing and debugging tool.
+/// External names can also serve as a primitive testing and debugging tool.
 /// In particular, many `.cton` test files use function names to identify
 /// functions.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct FunctionName(NameRepr);
+pub struct ExternalName(NameRepr);
 
-impl FunctionName {
-    /// Creates a new function name from a sequence of bytes.
+impl ExternalName {
+    /// Creates a new external name from a sequence of bytes.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// # use cretonne::ir::FunctionName;
-    /// // Create `FunctionName` from a string.
-    /// let name = FunctionName::new("hello");
+    /// # use cretonne::ir::ExternalName;
+    /// // Create `ExternalName` from a string.
+    /// let name = ExternalName::new("hello");
     /// assert_eq!(name.to_string(), "%hello");
     ///
-    /// // Create `FunctionName` from a sequence of bytes.
+    /// // Create `ExternalName` from a sequence of bytes.
     /// let bytes: &[u8] = &[10, 9, 8];
-    /// let name = FunctionName::new(bytes);
+    /// let name = ExternalName::new(bytes);
     /// assert_eq!(name.to_string(), "#0a0908");
     /// ```
-    pub fn new<T>(v: T) -> FunctionName
+    pub fn new<T>(v: T) -> ExternalName
     where
         T: Into<Vec<u8>>,
     {
@@ -43,12 +44,12 @@ impl FunctionName {
             for (i, &byte) in vec.iter().enumerate() {
                 bytes[i] = byte;
             }
-            FunctionName(NameRepr::Short {
+            ExternalName(NameRepr::Short {
                 length: vec.len() as u8,
                 bytes: bytes,
             })
         } else {
-            FunctionName(NameRepr::Long(vec))
+            ExternalName(NameRepr::Long(vec))
         }
     }
 }
@@ -86,7 +87,7 @@ impl AsRef<[u8]> for NameRepr {
     }
 }
 
-impl AsRef<[u8]> for FunctionName {
+impl AsRef<[u8]> for ExternalName {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }
@@ -101,7 +102,7 @@ impl Default for NameRepr {
     }
 }
 
-impl fmt::Display for FunctionName {
+impl fmt::Display for ExternalName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(name) = try_as_name(self.0.as_ref()) {
             write!(f, "%{}", name)
@@ -117,24 +118,24 @@ impl fmt::Display for FunctionName {
 
 #[cfg(test)]
 mod tests {
-    use super::FunctionName;
+    use super::ExternalName;
 
     #[test]
     fn displaying() {
-        assert_eq!(FunctionName::new("").to_string(), "%");
-        assert_eq!(FunctionName::new("x").to_string(), "%x");
-        assert_eq!(FunctionName::new("x_1").to_string(), "%x_1");
-        assert_eq!(FunctionName::new(" ").to_string(), "#20");
+        assert_eq!(ExternalName::new("").to_string(), "%");
+        assert_eq!(ExternalName::new("x").to_string(), "%x");
+        assert_eq!(ExternalName::new("x_1").to_string(), "%x_1");
+        assert_eq!(ExternalName::new(" ").to_string(), "#20");
         assert_eq!(
-            FunctionName::new("кретон").to_string(),
+            ExternalName::new("кретон").to_string(),
             "#d0bad180d0b5d182d0bed0bd"
         );
         assert_eq!(
-            FunctionName::new("印花棉布").to_string(),
+            ExternalName::new("印花棉布").to_string(),
             "#e58db0e88ab1e6a389e5b883"
         );
         assert_eq!(
-            FunctionName::new(vec![0, 1, 2, 3, 4, 5]).to_string(),
+            ExternalName::new(vec![0, 1, 2, 3, 4, 5]).to_string(),
             "#000102030405"
         );
     }

--- a/lib/cretonne/src/ir/function.rs
+++ b/lib/cretonne/src/ir/function.rs
@@ -5,7 +5,7 @@
 
 use entity::{PrimaryMap, EntityMap};
 use ir;
-use ir::{FunctionName, CallConv, Signature, DataFlowGraph, Layout};
+use ir::{ExternalName, CallConv, Signature, DataFlowGraph, Layout};
 use ir::{InstEncodings, ValueLocations, JumpTables, StackSlots, EbbOffsets, SourceLocs};
 use ir::{Ebb, JumpTableData, JumpTable, StackSlotData, StackSlot, SigRef, ExtFuncData, FuncRef,
          GlobalVarData, GlobalVar, HeapData, Heap};
@@ -20,7 +20,7 @@ use write::write_function;
 #[derive(Clone)]
 pub struct Function {
     /// Name of this function. Mostly used by `.cton` files.
-    pub name: FunctionName,
+    pub name: ExternalName,
 
     /// Signature of this function.
     pub signature: Signature,
@@ -66,7 +66,7 @@ pub struct Function {
 
 impl Function {
     /// Create a function with the given name and signature.
-    pub fn with_name_signature(name: FunctionName, sig: Signature) -> Function {
+    pub fn with_name_signature(name: ExternalName, sig: Signature) -> Function {
         Function {
             name,
             signature: sig,
@@ -100,7 +100,7 @@ impl Function {
 
     /// Create a new empty, anonymous function with a native calling convention.
     pub fn new() -> Function {
-        Self::with_name_signature(FunctionName::default(), Signature::new(CallConv::Native))
+        Self::with_name_signature(ExternalName::default(), Signature::new(CallConv::Native))
     }
 
     /// Creates a jump table in the function, to be used by `br_table` instructions.

--- a/lib/cretonne/src/ir/globalvar.rs
+++ b/lib/cretonne/src/ir/globalvar.rs
@@ -1,6 +1,6 @@
 //! Global variables.
 
-use ir::GlobalVar;
+use ir::{ExternalName, GlobalVar};
 use ir::immediates::Offset32;
 use std::fmt;
 
@@ -25,6 +25,14 @@ pub enum GlobalVarData {
         /// Byte offset to be added to the pointer loaded from `base`.
         offset: Offset32,
     },
+
+    /// Variable is at an address identified by a symbolic name. Cretonne itself
+    /// does not interpret this name; it's used by embedders to link with other
+    /// data structures.
+    Sym {
+        /// The symbolic name.
+        name: ExternalName,
+    },
 }
 
 impl fmt::Display for GlobalVarData {
@@ -32,6 +40,7 @@ impl fmt::Display for GlobalVarData {
         match *self {
             GlobalVarData::VmCtx { offset } => write!(f, "vmctx{}", offset),
             GlobalVarData::Deref { base, offset } => write!(f, "deref({}){}", base, offset),
+            GlobalVarData::Sym { ref name } => write!(f, "globalsym {}", name),
         }
     }
 }

--- a/lib/cretonne/src/ir/mod.rs
+++ b/lib/cretonne/src/ir/mod.rs
@@ -12,7 +12,7 @@ pub mod layout;
 pub mod function;
 mod builder;
 mod extfunc;
-mod funcname;
+mod extname;
 mod globalvar;
 mod heap;
 mod memflags;
@@ -26,7 +26,7 @@ pub use ir::dfg::{DataFlowGraph, ValueDef};
 pub use ir::entities::{Ebb, Inst, Value, StackSlot, GlobalVar, JumpTable, FuncRef, SigRef, Heap};
 pub use ir::extfunc::{Signature, CallConv, AbiParam, ArgumentExtension, ArgumentPurpose,
                       ExtFuncData};
-pub use ir::funcname::FunctionName;
+pub use ir::extname::ExternalName;
 pub use ir::function::Function;
 pub use ir::globalvar::GlobalVarData;
 pub use ir::heap::{HeapData, HeapStyle, HeapBase};

--- a/lib/cretonne/src/legalizer/globalvar.rs
+++ b/lib/cretonne/src/legalizer/globalvar.rs
@@ -21,7 +21,7 @@ pub fn expand_global_addr(inst: ir::Inst, func: &mut ir::Function, _cfg: &mut Co
     match func.global_vars[gv] {
         ir::GlobalVarData::VmCtx { offset } => vmctx_addr(inst, func, offset.into()),
         ir::GlobalVarData::Deref { base, offset } => deref_addr(inst, func, base, offset.into()),
-        ir::GlobalVarData::Sym { .. } => (),
+        ir::GlobalVarData::Sym { .. } => globalsym(inst, func, gv),
     }
 }
 
@@ -49,4 +49,10 @@ fn deref_addr(inst: ir::Inst, func: &mut ir::Function, base: ir::GlobalVar, offs
     // TODO: We could probably set both `notrap` and `aligned` on this load instruction.
     let base_ptr = pos.ins().load(ptr_ty, ir::MemFlags::new(), base_addr, 0);
     pos.func.dfg.replace(inst).iadd_imm(base_ptr, offset);
+}
+
+/// Expand a `global_addr` instruction for a symbolic name global.
+fn globalsym(inst: ir::Inst, func: &mut ir::Function, gv: ir::GlobalVar) {
+    let ptr_ty = func.dfg.value_type(func.dfg.first_result(inst));
+    func.dfg.replace(inst).globalsym_addr(ptr_ty, gv);
 }

--- a/lib/cretonne/src/legalizer/globalvar.rs
+++ b/lib/cretonne/src/legalizer/globalvar.rs
@@ -21,6 +21,7 @@ pub fn expand_global_addr(inst: ir::Inst, func: &mut ir::Function, _cfg: &mut Co
     match func.global_vars[gv] {
         ir::GlobalVarData::VmCtx { offset } => vmctx_addr(inst, func, offset.into()),
         ir::GlobalVarData::Deref { base, offset } => deref_addr(inst, func, base, offset.into()),
+        ir::GlobalVarData::Sym { .. } => (),
     }
 }
 

--- a/lib/cretonne/src/settings.rs
+++ b/lib/cretonne/src/settings.rs
@@ -352,7 +352,8 @@ mod tests {
                     enable_float = true\n\
                     enable_simd = true\n\
                     enable_atomics = true\n\
-                    spiderwasm_prologue_words = 0\n"
+                    spiderwasm_prologue_words = 0\n\
+                    allones_funcaddrs = false\n"
         );
         assert_eq!(f.opt_level(), super::OptLevel::Default);
         assert_eq!(f.enable_simd(), true);

--- a/lib/cretonne/src/write.rs
+++ b/lib/cretonne/src/write.rs
@@ -441,7 +441,7 @@ impl<'a> fmt::Display for DisplayValues<'a> {
 
 #[cfg(test)]
 mod tests {
-    use ir::{Function, FunctionName, StackSlotData, StackSlotKind};
+    use ir::{Function, ExternalName, StackSlotData, StackSlotKind};
     use ir::types;
 
     #[test]
@@ -449,7 +449,7 @@ mod tests {
         let mut f = Function::new();
         assert_eq!(f.to_string(), "function %() native {\n}\n");
 
-        f.name = FunctionName::new("foo");
+        f.name = ExternalName::new("foo");
         assert_eq!(f.to_string(), "function %foo() native {\n}\n");
 
         f.create_stack_slot(StackSlotData::new(StackSlotKind::Local, 4));

--- a/lib/frontend/src/frontend.rs
+++ b/lib/frontend/src/frontend.rs
@@ -653,7 +653,7 @@ where
 mod tests {
 
     use cretonne::entity::EntityRef;
-    use cretonne::ir::{FunctionName, Function, CallConv, Signature, AbiParam, InstBuilder};
+    use cretonne::ir::{ExternalName, Function, CallConv, Signature, AbiParam, InstBuilder};
     use cretonne::ir::types::*;
     use frontend::{ILBuilder, FunctionBuilder};
     use cretonne::verifier::verify_function;
@@ -687,7 +687,7 @@ mod tests {
         sig.params.push(AbiParam::new(I32));
 
         let mut il_builder = ILBuilder::<Variable>::new();
-        let mut func = Function::with_name_signature(FunctionName::new("sample_function"), sig);
+        let mut func = Function::with_name_signature(ExternalName::new("sample_function"), sig);
         {
             let mut builder = FunctionBuilder::<Variable>::new(&mut func, &mut il_builder);
 

--- a/lib/frontend/src/lib.rs
+++ b/lib/frontend/src/lib.rs
@@ -36,7 +36,7 @@
 //! extern crate cton_frontend;
 //!
 //! use cretonne::entity::EntityRef;
-//! use cretonne::ir::{FunctionName, CallConv, Function, Signature, AbiParam, InstBuilder};
+//! use cretonne::ir::{ExternalName, CallConv, Function, Signature, AbiParam, InstBuilder};
 //! use cretonne::ir::types::*;
 //! use cretonne::settings;
 //! use cton_frontend::{ILBuilder, FunctionBuilder};
@@ -67,7 +67,7 @@
 //!     sig.returns.push(AbiParam::new(I32));
 //!     sig.params.push(AbiParam::new(I32));
 //!     let mut il_builder = ILBuilder::<Variable>::new();
-//!     let mut func = Function::with_name_signature(FunctionName::new("sample_function"), sig);
+//!     let mut func = Function::with_name_signature(ExternalName::new("sample_function"), sig);
 //!     {
 //!         let mut builder = FunctionBuilder::<Variable>::new(&mut func, &mut il_builder);
 //!

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::{u16, u32};
 use std::mem;
-use cretonne::ir::{Function, Ebb, Opcode, Value, Type, FunctionName, CallConv, StackSlotData,
+use cretonne::ir::{Function, Ebb, Opcode, Value, Type, ExternalName, CallConv, StackSlotData,
                    JumpTable, JumpTableData, Signature, AbiParam, ArgumentExtension, ExtFuncData,
                    SigRef, FuncRef, StackSlot, ValueLoc, ArgumentLoc, MemFlags, GlobalVar,
                    GlobalVarData, Heap, HeapData, HeapStyle, HeapBase};
@@ -872,7 +872,7 @@ impl<'a> Parser<'a> {
     fn parse_function_spec(
         &mut self,
         unique_isa: Option<&TargetIsa>,
-    ) -> Result<(Location, FunctionName, Signature)> {
+    ) -> Result<(Location, ExternalName, Signature)> {
         self.match_identifier("function", "expected 'function'")?;
         let location = self.loc;
 
@@ -889,11 +889,11 @@ impl<'a> Parser<'a> {
     //
     // function ::= "function" * name signature { ... }
     //
-    fn parse_function_name(&mut self) -> Result<FunctionName> {
+    fn parse_function_name(&mut self) -> Result<ExternalName> {
         match self.token() {
             Some(Token::Name(s)) => {
                 self.consume();
-                Ok(FunctionName::new(s))
+                Ok(ExternalName::new(s))
             }
             Some(Token::HexSequence(s)) => {
                 if s.len() % 2 != 0 {
@@ -910,7 +910,7 @@ impl<'a> Parser<'a> {
                     i += 2;
                 }
                 self.consume();
-                Ok(FunctionName::new(bin_name))
+                Ok(ExternalName::new(bin_name))
             }
             _ => err!(self.loc, "expected function name"),
         }

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -9,9 +9,9 @@ use cretonne::settings;
 use wasmparser;
 use std::error::Error;
 
-/// Compute a `ir::FunctionName` for a given wasm function index.
-fn get_func_name(func_index: FunctionIndex) -> ir::FunctionName {
-    ir::FunctionName::new(format!("wasm_0x{:x}", func_index))
+/// Compute a `ir::ExternalName` for a given wasm function index.
+fn get_func_name(func_index: FunctionIndex) -> ir::ExternalName {
+    ir::ExternalName::new(format!("wasm_0x{:x}", func_index))
 }
 
 /// A collection of names under which a given entity is exported.
@@ -196,7 +196,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
 }
 
 impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
-    fn get_func_name(&self, func_index: FunctionIndex) -> ir::FunctionName {
+    fn get_func_name(&self, func_index: FunctionIndex) -> ir::ExternalName {
         get_func_name(func_index)
     }
 

--- a/lib/wasm/src/environ/spec.rs
+++ b/lib/wasm/src/environ/spec.rs
@@ -151,7 +151,7 @@ pub trait FuncEnvironment {
 /// by the user, they are only for `cretonne-wasm` internal use.
 pub trait ModuleEnvironment<'data> {
     /// Return the name for the given function index.
-    fn get_func_name(&self, func_index: FunctionIndex) -> ir::FunctionName;
+    fn get_func_name(&self, func_index: FunctionIndex) -> ir::ExternalName;
 
     /// Declares a function signature to the environment.
     fn declare_signature(&mut self, sig: &ir::Signature);

--- a/lib/wasm/src/func_translator.rs
+++ b/lib/wasm/src/func_translator.rs
@@ -255,7 +255,7 @@ mod tests {
         let runtime = DummyEnvironment::default();
         let mut ctx = Context::new();
 
-        ctx.func.name = ir::FunctionName::new("small1");
+        ctx.func.name = ir::ExternalName::new("small1");
         ctx.func.signature.params.push(ir::AbiParam::new(I32));
         ctx.func.signature.returns.push(ir::AbiParam::new(I32));
 
@@ -286,7 +286,7 @@ mod tests {
         let runtime = DummyEnvironment::default();
         let mut ctx = Context::new();
 
-        ctx.func.name = ir::FunctionName::new("small2");
+        ctx.func.name = ir::ExternalName::new("small2");
         ctx.func.signature.params.push(ir::AbiParam::new(I32));
         ctx.func.signature.returns.push(ir::AbiParam::new(I32));
 
@@ -326,7 +326,7 @@ mod tests {
         let runtime = DummyEnvironment::default();
         let mut ctx = Context::new();
 
-        ctx.func.name = ir::FunctionName::new("infloop");
+        ctx.func.name = ir::ExternalName::new("infloop");
         ctx.func.signature.returns.push(ir::AbiParam::new(I32));
 
         trans

--- a/src/filetest/binemit.rs
+++ b/src/filetest/binemit.rs
@@ -79,6 +79,10 @@ impl binemit::CodeSink for TextSink {
         write!(self.text, "{}({}) ", self.rnames[reloc.0 as usize], fref).unwrap();
     }
 
+    fn reloc_globalsym(&mut self, reloc: binemit::Reloc, global: ir::GlobalVar) {
+        write!(self.text, "{}({}) ", self.rnames[reloc.0 as usize], global).unwrap();
+    }
+
     fn reloc_jt(&mut self, reloc: binemit::Reloc, jt: ir::JumpTable) {
         write!(self.text, "{}({}) ", self.rnames[reloc.0 as usize], jt).unwrap();
     }

--- a/src/filetest/compile.rs
+++ b/src/filetest/compile.rs
@@ -99,5 +99,6 @@ impl binemit::CodeSink for SizeSink {
 
     fn reloc_ebb(&mut self, _reloc: binemit::Reloc, _ebb: ir::Ebb) {}
     fn reloc_func(&mut self, _reloc: binemit::Reloc, _fref: ir::FuncRef) {}
+    fn reloc_globalsym(&mut self, _reloc: binemit::Reloc, _global: ir::GlobalVar) {}
     fn reloc_jt(&mut self, _reloc: binemit::Reloc, _jt: ir::JumpTable) {}
 }


### PR DESCRIPTION
 This fixes #182. As it currently stands, it also makes several API changes that baldrdash would probably need to be updated for:
 - rename `FunctionName` to `ExternalName`
 - add a `reloc_globalsym` to any `RelocSink` impls (which could probably just panic since the frontend in that case wouldn't ever generate a globalsym)
 - enable the `allones_funcaddrs` setting
