### PR TITLE
Add a 'clear()' function to Context.

### DIFF
--- a/lib/cretonne/src/context.rs
+++ b/lib/cretonne/src/context.rs
@@ -57,6 +57,15 @@ impl Context {
         }
     }
 
+    /// Clear all data structures in this context.
+    pub fn clear(&mut self) {
+        self.func.clear();
+        self.cfg.clear();
+        self.domtree.clear();
+        self.regalloc.clear();
+        self.loop_analysis.clear();
+    }
+
     /// Compile the function.
     ///
     /// Run the function through all the passes necessary to generate code for the target ISA

--- a/lib/cretonne/src/flowgraph.rs
+++ b/lib/cretonne/src/flowgraph.rs
@@ -58,6 +58,12 @@ impl ControlFlowGraph {
         }
     }
 
+    /// Clear all data structures in this control flow graph.
+    pub fn clear(&mut self) {
+        self.data.clear();
+        self.valid = false;
+    }
+
     /// Allocate and compute the control flow graph for `func`.
     pub fn with_function(func: &Function) -> Self {
         let mut cfg = Self::new();

--- a/lib/cretonne/src/regalloc/coalescing.rs
+++ b/lib/cretonne/src/regalloc/coalescing.rs
@@ -81,6 +81,12 @@ impl DomForest {
         }
     }
 
+    /// Clear all data structures in this dominator forest.
+    pub fn clear(&mut self) {
+        self.values.clear();
+        self.stack.clear();
+    }
+
     /// Swap the merged list with `buffer`, leaving the dominator forest empty.
     ///
     /// This is typically called after a successful merge to extract the merged value list.
@@ -141,8 +147,7 @@ impl DomForest {
         domtree: &DominatorTree,
         liveness: &Liveness,
     ) -> Result<(), (Value, Value)> {
-        self.stack.clear();
-        self.values.clear();
+        self.clear();
         self.values.reserve(va.len() + vb.len());
 
         // Convert the two value lists into a merged sequence of nodes.
@@ -259,6 +264,13 @@ impl Coalescing {
             split_values: Vec::new(),
         }
 
+    }
+
+    /// Clear all data structures in this coalescing pass.
+    pub fn clear(&mut self) {
+        self.forest.clear();
+        self.values.clear();
+        self.split_values.clear();
     }
 
     /// Convert `func` to conventional SSA form and build virtual registers in the process.

--- a/lib/cretonne/src/regalloc/coloring.rs
+++ b/lib/cretonne/src/regalloc/coloring.rs
@@ -108,6 +108,12 @@ impl Coloring {
         }
     }
 
+    /// Clear all data structures in this coloring pass.
+    pub fn clear(&mut self) {
+        self.divert.clear();
+        self.solver.clear();
+    }
+
     /// Run the coloring algorithm over `func`.
     pub fn run(
         &mut self,

--- a/lib/cretonne/src/regalloc/context.rs
+++ b/lib/cretonne/src/regalloc/context.rs
@@ -49,6 +49,18 @@ impl Context {
         }
     }
 
+    /// Clear all data structures in this context.
+    pub fn clear(&mut self) {
+        self.liveness.clear();
+        self.virtregs.clear();
+        self.coalescing.clear();
+        self.topo.clear();
+        self.tracker.clear();
+        self.spilling.clear();
+        self.reload.clear();
+        self.coloring.clear();
+    }
+
     /// Allocate registers in `func`.
     ///
     /// After register allocation, all values in `func` have been assigned to a register or stack

--- a/lib/cretonne/src/regalloc/liveness.rs
+++ b/lib/cretonne/src/regalloc/liveness.rs
@@ -307,6 +307,13 @@ impl Liveness {
         }
     }
 
+    /// Clear all data structures in this liveness analysis.
+    pub fn clear(&mut self) {
+        self.ranges.clear();
+        self.worklist.clear();
+        self.ebb_params.clear();
+    }
+
     /// Get the live range for `value`, if it exists.
     pub fn get(&self, value: Value) -> Option<&LiveRange> {
         self.ranges.get(value)

--- a/lib/cretonne/src/regalloc/reload.rs
+++ b/lib/cretonne/src/regalloc/reload.rs
@@ -53,6 +53,12 @@ impl Reload {
         }
     }
 
+    /// Clear all data structures in this reload pass.
+    pub fn clear(&mut self) {
+        self.candidates.clear();
+        self.reloads.clear();
+    }
+
     /// Run the reload algorithm over `func`.
     pub fn run(
         &mut self,

--- a/lib/cretonne/src/regalloc/solver.rs
+++ b/lib/cretonne/src/regalloc/solver.rs
@@ -515,6 +515,17 @@ impl Solver {
         }
     }
 
+    /// Clear all data structures in this coloring pass.
+    pub fn clear(&mut self) {
+        self.assignments.clear();
+        self.vars.clear();
+        self.inputs_done = false;
+        self.regs_in = AllocatableSet::new();
+        self.regs_out = AllocatableSet::new();
+        self.moves.clear();
+        self.fills.clear();
+    }
+
     /// Reset the solver state and prepare solving for a new instruction with an initial set of
     /// allocatable registers.
     ///

--- a/lib/cretonne/src/regalloc/spilling.rs
+++ b/lib/cretonne/src/regalloc/spilling.rs
@@ -70,6 +70,12 @@ impl Spilling {
         }
     }
 
+    /// Clear all data structures in this spilling pass.
+    pub fn clear(&mut self) {
+        self.spills.clear();
+        self.reg_uses.clear();
+    }
+
     /// Run the spilling algorithm over `func`.
     pub fn run(
         &mut self,

--- a/lib/cretonne/src/topo_order.rs
+++ b/lib/cretonne/src/topo_order.rs
@@ -35,6 +35,14 @@ impl TopoOrder {
         }
     }
 
+    /// Clear all data structures in this topological order.
+    pub fn clear(&mut self) {
+        self.preferred.clear();
+        self.next = 0;
+        self.visited.clear();
+        self.stack.clear();
+    }
+
     /// Reset and initialize with a preferred sequence of EBBs. The resulting topological order is
     /// guaranteed to contain all of the EBBs in `preferred` as well as any dominators.
     pub fn reset<Ebbs>(&mut self, preferred: Ebbs)


### PR DESCRIPTION
This includes adding `clear()` functions to its (transitive) members.