### PR TITLE
Change representation of ir::ExternalName

### DIFF
--- a/filetests/isa/intel/abi64.cton
+++ b/filetests/isa/intel/abi64.cton
@@ -21,7 +21,7 @@ ebb0:
 
 function %pass_stack_int64(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 vmctx) spiderwasm {
     sig0 = (i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 vmctx) spiderwasm
-    fn0 = sig0 #00000000
+    fn0 = sig0 u0:0
 
 ebb0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v8: i64, v9: i64, v10: i64, v11: i64, v12: i64, v13: i64, v14: i64, v15: i64, v16: i64, v17: i64, v18: i64, v19: i64, v20: i64):
     call fn0(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20)

--- a/filetests/isa/intel/legalize-memory.cton
+++ b/filetests/isa/intel/legalize-memory.cton
@@ -31,7 +31,7 @@ ebb1(v1: i64):
 
 function %sym() -> i64 {
     gv0 = globalsym %something
-    gv1 = globalsym #d0bad180d0b5d182d0bed0bd
+    gv1 = globalsym u123:456
 
 ebb1:
     v0 = global_addr.i64 gv0

--- a/filetests/parser/memory.cton
+++ b/filetests/parser/memory.cton
@@ -39,8 +39,8 @@ ebb0:
 function %sym() -> i32 {
     gv0 = globalsym %something
     ; check: $gv0 = globalsym %something
-    gv1 = globalsym #d0bad180d0b5d182d0bed0bd
-    ; check: $gv1 = globalsym #d0bad180d0b5d182d0bed0bd
+    gv1 = globalsym u8:9
+    ; check: $gv1 = globalsym u8:9
 ebb0:
     v0 = global_addr.i32 gv0
     ; check: $v0 = global_addr.i32 $gv0

--- a/filetests/regalloc/iterate.cton
+++ b/filetests/regalloc/iterate.cton
@@ -2,7 +2,7 @@ test regalloc
 set is_64bit
 isa intel haswell
 
-function #00000009(i64 [%rdi], f32 [%xmm0], f64 [%xmm1], i32 [%rsi], i32 [%rdx], i64 vmctx [%r14]) -> i64 [%rax] spiderwasm {
+function u0:9(i64 [%rdi], f32 [%xmm0], f64 [%xmm1], i32 [%rsi], i32 [%rdx], i64 vmctx [%r14]) -> i64 [%rax] spiderwasm {
 ebb0(v0: i64, v1: f32, v2: f64, v3: i32, v4: i32, v5: i64):
     v32 = iconst.i32 0
     v6 = bitcast.f32 v32
@@ -104,7 +104,7 @@ ebb1(v31: i64):
     return v31
 }
 
-function #0000001a(i64 vmctx [%r14]) -> i64 [%rax] spiderwasm {
+function u0:26(i64 vmctx [%r14]) -> i64 [%rax] spiderwasm {
     gv0 = vmctx+48
     sig0 = (i32 [%rdi], i64 [%rsi], i64 vmctx [%r14], i64 sigid [%rbx]) -> i64 [%rax] spiderwasm
 

--- a/lib/cretonne/src/ir/extname.rs
+++ b/lib/cretonne/src/ir/extname.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::{self, Write};
 
-const TESTCASE_NAME_LENGTH: usize = 10;
+const TESTCASE_NAME_LENGTH: usize = 16;
 
 /// The name of an external is either a reference to a user-defined symbol
 /// table, or a short sequence of ascii bytes so that test cases do not have
@@ -118,13 +118,13 @@ mod tests {
         assert_eq!(ExternalName::testcase("x").to_string(), "%x");
         assert_eq!(ExternalName::testcase("x_1").to_string(), "%x_1");
         assert_eq!(
-            ExternalName::testcase("long123456").to_string(),
-            "%long123456"
+            ExternalName::testcase("longname12345678").to_string(),
+            "%longname12345678"
         );
-        // Constructor will silently drop bytes beyond the 10th
+        // Constructor will silently drop bytes beyond the 16th
         assert_eq!(
-            ExternalName::testcase("long1234567").to_string(),
-            "%long123456"
+            ExternalName::testcase("longname123456789").to_string(),
+            "%longname12345678"
         );
     }
 

--- a/lib/cretonne/src/write.rs
+++ b/lib/cretonne/src/write.rs
@@ -447,9 +447,9 @@ mod tests {
     #[test]
     fn basic() {
         let mut f = Function::new();
-        assert_eq!(f.to_string(), "function %() native {\n}\n");
+        assert_eq!(f.to_string(), "function u0:0() native {\n}\n");
 
-        f.name = ExternalName::new("foo");
+        f.name = ExternalName::testcase("foo");
         assert_eq!(f.to_string(), "function %foo() native {\n}\n");
 
         f.create_stack_slot(StackSlotData::new(StackSlotKind::Local, 4));

--- a/lib/frontend/src/frontend.rs
+++ b/lib/frontend/src/frontend.rs
@@ -613,7 +613,7 @@ mod tests {
         sig.params.push(AbiParam::new(I32));
 
         let mut il_builder = ILBuilder::<Variable>::new();
-        let mut func = Function::with_name_signature(ExternalName::new("sample_function"), sig);
+        let mut func = Function::with_name_signature(ExternalName::testcase("sample"), sig);
         {
             let mut builder = FunctionBuilder::<Variable>::new(&mut func, &mut il_builder);
 

--- a/lib/frontend/src/lib.rs
+++ b/lib/frontend/src/lib.rs
@@ -62,7 +62,7 @@
 //!     sig.returns.push(AbiParam::new(I32));
 //!     sig.params.push(AbiParam::new(I32));
 //!     let mut il_builder = ILBuilder::<Variable>::new();
-//!     let mut func = Function::with_name_signature(ExternalName::new("sample_function"), sig);
+//!     let mut func = Function::with_name_signature(ExternalName::user(0, 0), sig);
 //!     {
 //!         let mut builder = FunctionBuilder::<Variable>::new(&mut func, &mut il_builder);
 //!

--- a/lib/reader/src/lexer.rs
+++ b/lib/reader/src/lexer.rs
@@ -38,6 +38,7 @@ pub enum Token<'a> {
     JumpTable(u32), // jt2
     FuncRef(u32), // fn2
     SigRef(u32), // sig2
+    UserRef(u32), // u345
     Name(&'a str), // %9arbitrary_alphanum, %x3, %0, %function ...
     HexSequence(&'a str), // #89AF
     Identifier(&'a str), // Unrecognized identifier (opcode, enumerator, ...)
@@ -320,6 +321,7 @@ impl<'a> Lexer<'a> {
             "jt" => Some(Token::JumpTable(number)),
             "fn" => Some(Token::FuncRef(number)),
             "sig" => Some(Token::SigRef(number)),
+            "u" => Some(Token::UserRef(number)),
             _ => None,
         }
     }
@@ -603,5 +605,18 @@ mod tests {
         assert_eq!(lex.next(), token(Token::Name("v3"), 1));
         assert_eq!(lex.next(), token(Token::Name("ebb11"), 1));
         assert_eq!(lex.next(), token(Token::Name("_"), 1));
+    }
+
+    #[test]
+    fn lex_userrefs() {
+        let mut lex = Lexer::new("u0 u1 u234567890 u9:8765");
+
+        assert_eq!(lex.next(), token(Token::UserRef(0), 1));
+        assert_eq!(lex.next(), token(Token::UserRef(1), 1));
+        assert_eq!(lex.next(), token(Token::UserRef(234567890), 1));
+        assert_eq!(lex.next(), token(Token::UserRef(9), 1));
+        assert_eq!(lex.next(), token(Token::Colon, 1));
+        assert_eq!(lex.next(), token(Token::Integer("8765"), 1));
+        assert_eq!(lex.next(), None);
     }
 }

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -2584,45 +2584,50 @@ mod tests {
     }
 
     #[test]
-    fn binary_function_name() {
-        // Valid characters in the name.
+    fn user_function_name() {
+        // Valid characters in the name:
         let func = Parser::new(
-            "function #1234567890AbCdEf() native {
+            "function u1:2() native {
                                            ebb0:
                                              trap int_divz
                                            }",
         ).parse_function(None)
             .unwrap()
             .0;
-        assert_eq!(func.name.to_string(), "#1234567890abcdef");
+        assert_eq!(func.name.to_string(), "u1:2");
 
-        // Invalid characters in the name.
+        // Invalid characters in the name:
         let mut parser = Parser::new(
-            "function #12ww() native {
+            "function u123:abc() native {
                                            ebb0:
                                              trap stk_ovf
                                            }",
         );
         assert!(parser.parse_function(None).is_err());
 
-        // The length of binary function name should be multiple of two.
+        // Incomplete function names should not be valid:
         let mut parser = Parser::new(
-            "function #1() native {
+            "function u() native {
                                            ebb0:
-                                             trap user0
+                                             trap int_ovf
                                            }",
         );
         assert!(parser.parse_function(None).is_err());
 
-        // Empty binary function name should be valid.
-        let func = Parser::new(
-            "function #() native {
+        let mut parser = Parser::new(
+            "function u0() native {
                                            ebb0:
                                              trap int_ovf
                                            }",
-        ).parse_function(None)
-            .unwrap()
-            .0;
-        assert_eq!(func.name.to_string(), "%");
+        );
+        assert!(parser.parse_function(None).is_err());
+
+        let mut parser = Parser::new(
+            "function u0:() native {
+                                           ebb0:
+                                             trap int_ovf
+                                           }",
+        );
+        assert!(parser.parse_function(None).is_err());
     }
 }

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -13,7 +13,7 @@ use std::error::Error;
 
 /// Compute a `ir::ExternalName` for a given wasm function index.
 fn get_func_name(func_index: FunctionIndex) -> ir::ExternalName {
-    ir::ExternalName::new(format!("wasm_0x{:x}", func_index))
+    ir::ExternalName::user(0, func_index as u32)
 }
 
 /// A collection of names under which a given entity is exported.

--- a/lib/wasm/src/func_translator.rs
+++ b/lib/wasm/src/func_translator.rs
@@ -252,7 +252,7 @@ mod tests {
         let runtime = DummyEnvironment::default();
         let mut ctx = Context::new();
 
-        ctx.func.name = ir::ExternalName::new("small1");
+        ctx.func.name = ir::ExternalName::testcase("small1");
         ctx.func.signature.params.push(ir::AbiParam::new(I32));
         ctx.func.signature.returns.push(ir::AbiParam::new(I32));
 
@@ -283,7 +283,7 @@ mod tests {
         let runtime = DummyEnvironment::default();
         let mut ctx = Context::new();
 
-        ctx.func.name = ir::ExternalName::new("small2");
+        ctx.func.name = ir::ExternalName::testcase("small2");
         ctx.func.signature.params.push(ir::AbiParam::new(I32));
         ctx.func.signature.returns.push(ir::AbiParam::new(I32));
 
@@ -323,7 +323,7 @@ mod tests {
         let runtime = DummyEnvironment::default();
         let mut ctx = Context::new();
 
-        ctx.func.name = ir::ExternalName::new("infloop");
+        ctx.func.name = ir::ExternalName::testcase("infloop");
         ctx.func.signature.returns.push(ir::AbiParam::new(I32));
 
         trans


### PR DESCRIPTION
Implements proposal discussed in https://github.com/stoklund/cretonne/issues/194

The `LibCall` variant is not implemented. I can implement it if you'd like.

The only major change not discussed there was that TestCase is 16 ascii characters, instead of 10, in order to prevent me from having to go change the dozen or so filetests that use testcase names that are between 10 and 16 characters long. None were over 16 characters.

I removed `wat2wasm` from my PATH to get all tests to pass for this PR. I will make a separate PR next week that fixes up what appear to be some minor issues with the wasm tests.

Have a happy thanksgiving!