### PR TITLE
Opt-out std feature added to several internal crates.

### DIFF
--- a/lib/cretonne/Cargo.toml
+++ b/lib/cretonne/Cargo.toml
@@ -13,7 +13,8 @@ build = "build.rs"
 # cretonne supports `no_std`
 # Using `std` is default, however
 default = ["std"]
-std = []
+# workaround cargo not letting you conditionally *not* include dependencies
+std = ["hashmap_core/disable"]
 
 [lib]
 name = "cretonne"
@@ -23,3 +24,6 @@ name = "cretonne"
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be
 # accomodated in `tests`.
+
+[dependencies.hashmap_core]
+version = "0.1.1"

--- a/lib/cretonne/Cargo.toml
+++ b/lib/cretonne/Cargo.toml
@@ -9,6 +9,12 @@ repository = "https://github.com/stoklund/cretonne"
 publish = false
 build = "build.rs"
 
+[features]
+# cretonne supports `no_std`
+# Using `std` is default, however
+default = ["std"]
+std = []
+
 [lib]
 name = "cretonne"
 

--- a/lib/cretonne/src/abi.rs
+++ b/lib/cretonne/src/abi.rs
@@ -5,6 +5,7 @@
 
 use ir::{ArgumentLoc, AbiParam, ArgumentExtension, Type};
 use std::cmp::Ordering;
+use std::vec::Vec;
 
 /// Legalization action to perform on a single argument or return value when converting a
 /// signature.

--- a/lib/cretonne/src/dbg.rs
+++ b/lib/cretonne/src/dbg.rs
@@ -43,7 +43,7 @@ pub fn enabled() -> bool {
         false
     }
 }
-// Default to false when not linked against `stdlib`
+/// Default to false when not linked against `stdlib`
 #[cfg(not(feature = "std"))]
 #[inline]
 pub fn enabled() -> bool {

--- a/lib/cretonne/src/dbg.rs
+++ b/lib/cretonne/src/dbg.rs
@@ -10,8 +10,9 @@
 /// thread doing the logging.
 
 use std::fmt;
-use std::sync::atomic;
 
+#[cfg(feature = "std")]
+use std::sync::atomic;
 #[cfg(feature = "std")]
 use std::{env, thread};
 #[cfg(feature = "std")]
@@ -23,6 +24,7 @@ use std::fs::File;
 #[cfg(feature = "std")]
 use std::io::{self, Write};
 
+#[cfg(feature = "std")]
 static STATE: atomic::AtomicIsize = atomic::ATOMIC_ISIZE_INIT;
 
 /// Is debug tracing enabled?
@@ -83,6 +85,11 @@ pub fn writeln_with_format_args(args: fmt::Arguments) -> io::Result<()> {
         w.flush()
     })
 }
+/// Used as a sinkhole when not linked against `stdlib`
+#[cfg(not(feature = "std"))]
+pub fn writeln_with_format_args(_args: fmt::Arguments) -> Result<(), ()> {
+    Ok(())
+}
 
 /// Open the tracing file for the current thread.
 #[cfg(feature = "std")]
@@ -113,7 +120,6 @@ macro_rules! dbg {
         if $crate::dbg::enabled() {
             // Drop the error result so we don't get compiler errors for ignoring it.
             // What are you going to do, log the error?
-            #[cfg(feature = "std")]
             $crate::dbg::writeln_with_format_args(format_args!($($arg)+)).ok();
         }
     }

--- a/lib/cretonne/src/dominator_tree.rs
+++ b/lib/cretonne/src/dominator_tree.rs
@@ -7,6 +7,7 @@ use ir::instructions::BranchInfo;
 use packed_option::PackedOption;
 
 use std::cmp::Ordering;
+use std::vec::Vec;
 
 // RPO numbers are not first assigned in a contiguous way but as multiples of STRIDE, to leave
 // room for modifications of the dominator tree.

--- a/lib/cretonne/src/entity/list.rs
+++ b/lib/cretonne/src/entity/list.rs
@@ -3,6 +3,7 @@ use entity::EntityRef;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::mem;
+use std::vec::Vec;
 
 /// A small list of entity references allocated from a pool.
 ///

--- a/lib/cretonne/src/entity/map.rs
+++ b/lib/cretonne/src/entity/map.rs
@@ -3,6 +3,7 @@
 use entity::{EntityRef, Keys};
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
+use std::vec::Vec;
 
 /// A mapping `K -> V` for densely indexed entity references.
 ///

--- a/lib/cretonne/src/entity/primary.rs
+++ b/lib/cretonne/src/entity/primary.rs
@@ -2,6 +2,7 @@
 use entity::{EntityRef, Keys};
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
+use std::vec::Vec;
 
 /// A primary mapping `K -> V` allocating dense entity references.
 ///

--- a/lib/cretonne/src/entity/set.rs
+++ b/lib/cretonne/src/entity/set.rs
@@ -2,6 +2,7 @@
 
 use entity::{EntityRef, Keys};
 use std::marker::PhantomData;
+use std::vec::Vec;
 
 /// A set of `K` for densely indexed entity references.
 ///

--- a/lib/cretonne/src/entity/sparse.rs
+++ b/lib/cretonne/src/entity/sparse.rs
@@ -11,6 +11,7 @@ use entity::{EntityRef, EntityMap};
 use std::mem;
 use std::slice;
 use std::u32;
+use std::vec::Vec;
 
 /// Trait for extracting keys from values stored in a `SparseMap`.
 ///

--- a/lib/cretonne/src/ir/extfunc.rs
+++ b/lib/cretonne/src/ir/extfunc.rs
@@ -10,6 +10,7 @@ use isa::{RegInfo, RegUnit};
 use std::cmp;
 use std::fmt;
 use std::str::FromStr;
+use std::vec::Vec;
 
 /// Function signature.
 ///

--- a/lib/cretonne/src/ir/extname.rs
+++ b/lib/cretonne/src/ir/extname.rs
@@ -5,6 +5,7 @@
 //! Cretonne, which compiles functions independently.
 
 use std::fmt::{self, Write};
+use std::vec::Vec;
 
 const TESTCASE_NAME_LENGTH: usize = 16;
 

--- a/lib/cretonne/src/ir/instructions.rs
+++ b/lib/cretonne/src/ir/instructions.rs
@@ -9,6 +9,7 @@
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 use std::ops::{Deref, DerefMut};
+use std::vec::Vec;
 
 use ir;
 use ir::{Value, Type, Ebb, JumpTable, SigRef, FuncRef, StackSlot, MemFlags};

--- a/lib/cretonne/src/ir/jumptable.rs
+++ b/lib/cretonne/src/ir/jumptable.rs
@@ -8,6 +8,7 @@ use ir::entities::Ebb;
 use std::iter;
 use std::slice;
 use std::fmt::{self, Display, Formatter};
+use std::vec::Vec;
 
 /// Contents of a jump table.
 ///

--- a/lib/cretonne/src/ir/stackslot.rs
+++ b/lib/cretonne/src/ir/stackslot.rs
@@ -10,6 +10,7 @@ use std::cmp;
 use std::fmt;
 use std::ops::Index;
 use std::str::FromStr;
+use std::vec::Vec;
 
 /// The size of an object on the stack, or the size of a stack frame.
 ///

--- a/lib/cretonne/src/isa/arm32/mod.rs
+++ b/lib/cretonne/src/isa/arm32/mod.rs
@@ -14,6 +14,8 @@ use isa::{TargetIsa, RegInfo, RegClass, EncInfo};
 use ir;
 use regalloc;
 
+use std::boxed::Box;
+
 #[allow(dead_code)]
 struct Isa {
     shared_flags: shared_settings::Flags,

--- a/lib/cretonne/src/isa/arm64/mod.rs
+++ b/lib/cretonne/src/isa/arm64/mod.rs
@@ -14,6 +14,8 @@ use isa::{TargetIsa, RegInfo, RegClass, EncInfo};
 use ir;
 use regalloc;
 
+use std::boxed::Box;
+
 #[allow(dead_code)]
 struct Isa {
     shared_flags: shared_settings::Flags,

--- a/lib/cretonne/src/isa/intel/mod.rs
+++ b/lib/cretonne/src/isa/intel/mod.rs
@@ -14,6 +14,8 @@ use isa::{TargetIsa, RegInfo, RegClass, EncInfo};
 use ir;
 use regalloc;
 
+use std::boxed::Box;
+
 #[allow(dead_code)]
 struct Isa {
     shared_flags: shared_settings::Flags,

--- a/lib/cretonne/src/isa/mod.rs
+++ b/lib/cretonne/src/isa/mod.rs
@@ -53,6 +53,8 @@ use regalloc;
 use result;
 use isa::enc_tables::Encodings;
 
+use std::boxed::Box;
+
 #[cfg(build_riscv)]
 pub mod riscv;
 

--- a/lib/cretonne/src/isa/riscv/mod.rs
+++ b/lib/cretonne/src/isa/riscv/mod.rs
@@ -14,6 +14,8 @@ use isa::{TargetIsa, RegInfo, RegClass, EncInfo};
 use ir;
 use regalloc;
 
+use std::boxed::Box;
+
 #[allow(dead_code)]
 struct Isa {
     shared_flags: shared_settings::Flags,

--- a/lib/cretonne/src/legalizer/boundary.rs
+++ b/lib/cretonne/src/legalizer/boundary.rs
@@ -25,6 +25,7 @@ use ir::{Function, DataFlowGraph, Inst, InstBuilder, Ebb, Type, Value, Signature
 use ir::instructions::CallInfo;
 use isa::TargetIsa;
 use legalizer::split::{isplit, vsplit};
+use std::vec::Vec;
 
 /// Legalize all the function signatures in `func`.
 ///

--- a/lib/cretonne/src/legalizer/split.rs
+++ b/lib/cretonne/src/legalizer/split.rs
@@ -68,6 +68,7 @@ use cursor::{Cursor, CursorPosition, FuncCursor};
 use flowgraph::ControlFlowGraph;
 use ir::{self, Ebb, Inst, Value, Type, Opcode, ValueDef, InstructionData, InstBuilder};
 use std::iter;
+use std::vec::Vec;
 
 /// Split `value` into two values using the `isplit` semantics. Do this by reusing existing values
 /// if possible.

--- a/lib/cretonne/src/lib.rs
+++ b/lib/cretonne/src/lib.rs
@@ -7,6 +7,8 @@
 
 #[cfg(not(feature = "std"))]
 #[macro_use] extern crate alloc;
+#[cfg(not(feature = "std"))]
+extern crate hashmap_core;
 
 // create a psuedo-`std` module for use when not linking against `stdlib`
 #[cfg(not(feature = "std"))]
@@ -14,6 +16,8 @@ mod std {
     pub use alloc::{boxed, vec, string, borrow, slice};
     pub mod collections {
         pub use alloc::BTreeSet;
+        pub use hashmap_core::{HashMap, HashSet};
+        pub use hashmap_core::map as hash_map;
     }
     pub use core::{
         result, sync, fmt, hash, cmp, mem, marker, ops, ptr, convert, str, iter, u16, i32, u32, f32, f64, default, char

--- a/lib/cretonne/src/lib.rs
+++ b/lib/cretonne/src/lib.rs
@@ -1,6 +1,25 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
+
 //! Cretonne code generation library.
 
 #![deny(missing_docs)]
+
+#[cfg(not(feature = "std"))]
+#[macro_use] extern crate alloc;
+
+// create a psuedo-`std` module for use when not linking against `stdlib`
+#[cfg(not(feature = "std"))]
+mod std {
+    pub use alloc::{boxed, vec, string, borrow, slice};
+    pub mod collections {
+        pub use alloc::BTreeSet;
+    }
+    pub use core::{
+        result, sync, fmt, hash, cmp, mem, marker, ops, ptr, convert, str, iter, u16, i32, u32, f32, f64, default, char
+    };
+}
+
 
 pub use context::Context;
 pub use legalizer::legalize_function;

--- a/lib/cretonne/src/licm.rs
+++ b/lib/cretonne/src/licm.rs
@@ -8,6 +8,8 @@ use dominator_tree::DominatorTree;
 use entity::{EntityList, ListPool};
 use loop_analysis::{Loop, LoopAnalysis};
 
+use std::vec::Vec;
+
 /// Performs the LICM pass by detecting loops within the CFG and moving
 /// loop-invariant instructions out of them.
 /// Changes the CFG and domtree in-place during the operation.

--- a/lib/cretonne/src/loop_analysis.rs
+++ b/lib/cretonne/src/loop_analysis.rs
@@ -7,6 +7,7 @@ use entity::EntityMap;
 use flowgraph::ControlFlowGraph;
 use ir::{Function, Ebb, Layout};
 use packed_option::PackedOption;
+use std::vec::Vec;
 
 /// A opaque reference to a code loop.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]

--- a/lib/cretonne/src/regalloc/coalescing.rs
+++ b/lib/cretonne/src/regalloc/coalescing.rs
@@ -17,6 +17,7 @@ use regalloc::virtregs::VirtRegs;
 use std::cmp::Ordering;
 use std::iter::Peekable;
 use std::mem;
+use std::vec::Vec;
 use isa::{TargetIsa, EncInfo};
 
 /// Dominator forest.

--- a/lib/cretonne/src/regalloc/diversion.rs
+++ b/lib/cretonne/src/regalloc/diversion.rs
@@ -11,6 +11,7 @@ use ir::{Value, ValueLoc, ValueLocations, StackSlot};
 use ir::{InstructionData, Opcode};
 use isa::{RegUnit, RegInfo};
 use std::fmt;
+use std::vec::Vec;
 
 /// A diversion of a value from its original location to a new register or stack location.
 ///

--- a/lib/cretonne/src/regalloc/live_value_tracker.rs
+++ b/lib/cretonne/src/regalloc/live_value_tracker.rs
@@ -13,6 +13,7 @@ use regalloc::affinity::Affinity;
 use regalloc::liveness::Liveness;
 use regalloc::liverange::LiveRange;
 use std::collections::HashMap;
+use std::vec::Vec;
 
 type ValueList = EntityList<Value>;
 

--- a/lib/cretonne/src/regalloc/liveness.rs
+++ b/lib/cretonne/src/regalloc/liveness.rs
@@ -184,6 +184,7 @@ use regalloc::affinity::Affinity;
 use regalloc::liverange::LiveRange;
 use std::mem;
 use std::ops::Index;
+use std::vec::Vec;
 
 /// A set of live ranges, indexed by value number.
 type LiveRangeSet = SparseMap<Value, LiveRange>;

--- a/lib/cretonne/src/regalloc/liverange.rs
+++ b/lib/cretonne/src/regalloc/liverange.rs
@@ -111,6 +111,7 @@ use entity::SparseMapValue;
 use ir::{Inst, Ebb, Value, ProgramPoint, ExpandedProgramPoint, ProgramOrder};
 use regalloc::affinity::Affinity;
 use std::cmp::Ordering;
+use std::vec::Vec;
 
 /// Global live range of a single SSA value.
 ///

--- a/lib/cretonne/src/regalloc/reload.rs
+++ b/lib/cretonne/src/regalloc/reload.rs
@@ -20,6 +20,7 @@ use regalloc::affinity::Affinity;
 use regalloc::live_value_tracker::{LiveValue, LiveValueTracker};
 use regalloc::liveness::Liveness;
 use topo_order::TopoOrder;
+use std::vec::Vec;
 
 /// Reusable data structures for the reload pass.
 pub struct Reload {

--- a/lib/cretonne/src/regalloc/solver.rs
+++ b/lib/cretonne/src/regalloc/solver.rs
@@ -108,6 +108,7 @@ use std::fmt;
 use std::mem;
 use super::AllocatableSet;
 use std::u16;
+use std::vec::Vec;
 
 /// A variable in the constraint problem.
 ///

--- a/lib/cretonne/src/regalloc/spilling.rs
+++ b/lib/cretonne/src/regalloc/spilling.rs
@@ -26,6 +26,7 @@ use regalloc::liveness::Liveness;
 use regalloc::pressure::Pressure;
 use regalloc::virtregs::VirtRegs;
 use std::fmt;
+use std::vec::Vec;
 use topo_order::TopoOrder;
 
 /// Persistent data structures for the spilling pass.
@@ -429,7 +430,7 @@ impl<'a> Context<'a> {
     {
         // Find the best viable spill candidate.
         //
-        // The very simple strategy implemented here is to spill the value with the earliest def in
+    // The very simple strategy implemented here is to spill the value with the earliest def in
         // the reverse post-order. This strategy depends on a good reload pass to generate good
         // code.
         //

--- a/lib/cretonne/src/result.rs
+++ b/lib/cretonne/src/result.rs
@@ -43,7 +43,8 @@ pub type CtonResult = Result<(), CtonError>;
 
 #[cfg(not(feature = "std"))]
 impl CtonError {
-    fn description(&self) -> &str {
+    /// redefine `description` from `error::Error`
+    pub fn description(&self) -> &str {
         match *self {
             CtonError::InvalidInput => "Invalid input code",
             CtonError::Verifier(ref e) => &e.message,
@@ -51,7 +52,8 @@ impl CtonError {
             CtonError::CodeTooLarge => "Code for function is too large",
         }
     }
-    fn cause(&self) -> Option<&CtonError> {
+    /// redefine `cause` from `error::Error`
+    pub fn cause(&self) -> Option<&verifier::Error> {
         match *self {
             CtonError::Verifier(ref e) => Some(e),
             CtonError::InvalidInput |

--- a/lib/cretonne/src/result.rs
+++ b/lib/cretonne/src/result.rs
@@ -1,8 +1,10 @@
 //! Result and error types representing the outcome of compiling a function.
 
 use verifier;
-use std::error::Error as StdError;
 use std::fmt;
+
+#[cfg(feature = "std")]
+use std::error::Error as StdError;
 
 /// A compilation error.
 ///
@@ -39,6 +41,26 @@ pub enum CtonError {
 /// A Cretonne compilation result.
 pub type CtonResult = Result<(), CtonError>;
 
+#[cfg(not(feature = "std"))]
+impl CtonError {
+    fn description(&self) -> &str {
+        match *self {
+            CtonError::InvalidInput => "Invalid input code",
+            CtonError::Verifier(ref e) => &e.message,
+            CtonError::ImplLimitExceeded => "Implementation limit exceeded",
+            CtonError::CodeTooLarge => "Code for function is too large",
+        }
+    }
+    fn cause(&self) -> Option<&CtonError> {
+        match *self {
+            CtonError::Verifier(ref e) => Some(e),
+            CtonError::InvalidInput |
+            CtonError::ImplLimitExceeded |
+            CtonError::CodeTooLarge => None,
+        }
+    }
+}
+
 impl fmt::Display for CtonError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -50,6 +72,7 @@ impl fmt::Display for CtonError {
     }
 }
 
+#[cfg(feature = "std")]
 impl StdError for CtonError {
     fn description(&self) -> &str {
         match *self {

--- a/lib/cretonne/src/settings.rs
+++ b/lib/cretonne/src/settings.rs
@@ -24,6 +24,7 @@ use constant_hash::{probe, simple_hash};
 use isa::TargetIsa;
 use std::fmt;
 use std::result;
+use std::vec::Vec;
 
 /// A string-based configurator for settings groups.
 ///

--- a/lib/cretonne/src/simple_gvn.rs
+++ b/lib/cretonne/src/simple_gvn.rs
@@ -6,6 +6,8 @@ use dominator_tree::DominatorTree;
 use ir::{InstructionData, Function, Inst, Opcode, Type};
 use scoped_hash_map::ScopedHashMap;
 
+use std::vec::Vec;
+
 /// Test whether the given opcode is unsafe to even consider for GVN.
 fn trivially_unsafe_for_gvn(opcode: Opcode) -> bool {
     opcode.is_call() || opcode.is_branch() || opcode.is_terminator() ||

--- a/lib/cretonne/src/topo_order.rs
+++ b/lib/cretonne/src/topo_order.rs
@@ -4,6 +4,8 @@ use entity::SparseSet;
 use dominator_tree::DominatorTree;
 use ir::{Ebb, Layout};
 
+use std::vec::Vec;
+
 /// Present EBBs in a topological order such that all dominating EBBs are guaranteed to be visited
 /// before the current EBB.
 ///

--- a/lib/cretonne/src/verifier/mod.rs
+++ b/lib/cretonne/src/verifier/mod.rs
@@ -122,10 +122,12 @@ impl Display for Error {
 
 #[cfg(not(feature = "std"))]
 impl Error {
-    fn description(&self) -> &str {
+    /// Replacement for `error::Error::description`
+    pub fn description(&self) -> &str {
         &self.message
     }
-    fn cause(&self) -> Option<&Error> {
+    /// Replacement for `error::Error::cause`
+    pub fn cause(&self) -> Option<&Error> {
         None
     }
 }

--- a/lib/cretonne/src/verifier/mod.rs
+++ b/lib/cretonne/src/verifier/mod.rs
@@ -70,9 +70,14 @@ use self::flags::verify_flags;
 use settings::{Flags, FlagsOrIsa};
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
-use std::error as std_error;
 use std::fmt::{self, Display, Formatter, Write};
 use std::result;
+
+use std::vec::Vec;
+use std::string::String;
+
+#[cfg(feature = "std")]
+use std::error as std_error;
 
 pub use self::cssa::verify_cssa;
 pub use self::liveness::verify_liveness;
@@ -83,7 +88,7 @@ macro_rules! err {
     ( $loc:expr, $msg:expr ) => {
         Err(::verifier::Error {
             location: $loc.into(),
-            message: String::from($msg),
+            message: ::std::string::String::from($msg),
         })
     };
 
@@ -115,6 +120,17 @@ impl Display for Error {
     }
 }
 
+#[cfg(not(feature = "std"))]
+impl Error {
+    fn description(&self) -> &str {
+        &self.message
+    }
+    fn cause(&self) -> Option<&Error> {
+        None
+    }
+}
+
+#[cfg(feature = "std")]
 impl std_error::Error for Error {
     fn description(&self) -> &str {
         &self.message

--- a/lib/cretonne/src/write.rs
+++ b/lib/cretonne/src/write.rs
@@ -8,6 +8,7 @@ use ir::{Function, DataFlowGraph, Ebb, Inst, Value, ValueDef, Type};
 use isa::{TargetIsa, RegInfo};
 use std::fmt::{self, Result, Error, Write};
 use std::result;
+use std::string::String;
 
 /// Write `func` to `w` as equivalent text.
 /// Use `isa` to emit ISA-dependent annotations.

--- a/lib/frontend/Cargo.toml
+++ b/lib/frontend/Cargo.toml
@@ -8,8 +8,14 @@ documentation = "https://cretonne.readthedocs.io/"
 repository = "https://github.com/stoklund/cretonne"
 publish = false
 
+[features]
+# defaults to linking against `std` but supports `no_std`
+default = ["std"]
+std = ["cretonne/std"]
+
 [lib]
 name = "cton_frontend"
 
-[dependencies]
-cretonne = { path = "../cretonne" }
+[dependencies.cretonne]
+path = "../cretonne"
+default-features = false

--- a/lib/frontend/src/lib.rs
+++ b/lib/frontend/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
 //! Cretonne IL builder library.
 //!
 //! Provides a straightforward way to create a Cretonne IL function and fill it with instructions
@@ -143,6 +145,15 @@
 //! ```
 
 #![deny(missing_docs)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+mod std {
+    pub use core::{u32, mem};
+    pub use alloc::vec;
+}
 
 extern crate cretonne;
 

--- a/lib/frontend/src/ssa.rs
+++ b/lib/frontend/src/ssa.rs
@@ -15,6 +15,7 @@ use std::u32;
 use cretonne::ir::types::{F32, F64};
 use cretonne::ir::immediates::{Ieee32, Ieee64};
 use std::mem;
+use std::vec::Vec;
 
 /// Structure containing the data relevant the construction of SSA for a given function.
 ///

--- a/lib/native/Cargo.toml
+++ b/lib/native/Cargo.toml
@@ -7,11 +7,16 @@ description = "Support for targetting the host with Cretonne"
 repository = "https://github.com/stoklund/cretonne"
 license = "Apache-2.0"
 
+[features]
+default = ["std"]
+std = ["cretonne/std"]
+
 [lib]
 name = "cton_native"
 
-[dependencies]
-cretonne = { path = "../cretonne" }
+[dependencies.cretonne]
+path = "../cretonne"
+default-features = false
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 raw-cpuid = "3.0.0"

--- a/lib/native/src/lib.rs
+++ b/lib/native/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 //! Performs autodetection of the host for the purposes of running
 //! Cretonne to generate code to run on the same machine.
 

--- a/lib/reader/Cargo.toml
+++ b/lib/reader/Cargo.toml
@@ -8,8 +8,16 @@ documentation = "https://cretonne.readthedocs.io/"
 repository = "https://github.com/stoklund/cretonne"
 publish = false
 
+[features]
+default = ["std"]
+std = ["cretonne/std", "hashmap_core/disable"]
+
 [lib]
 name = "cton_reader"
 
-[dependencies]
-cretonne = { path = "../cretonne" }
+[dependencies.cretonne]
+path = "../cretonne"
+default-features = false
+
+[dependencies.hashmap_core]
+version = "0.1.1"

--- a/lib/reader/src/error.rs
+++ b/lib/reader/src/error.rs
@@ -4,6 +4,7 @@
 
 use std::fmt;
 use std::result;
+use std::string::String;
 
 /// The location of a `Token` or `Error`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -40,7 +41,7 @@ macro_rules! err {
     ( $loc:expr, $msg:expr ) => {
         Err($crate::Error {
             location: $loc.clone(),
-            message: String::from($msg),
+            message: ::std::string::String::from($msg),
         })
     };
 

--- a/lib/reader/src/isaspec.rs
+++ b/lib/reader/src/isaspec.rs
@@ -10,6 +10,8 @@ use cretonne::settings::{Flags, Configurable, Error as SetError};
 use cretonne::isa::TargetIsa;
 use error::{Result, Location};
 use testcommand::TestOption;
+use std::vec::Vec;
+use std::boxed::Box;
 
 /// The ISA specifications in a `.cton` file.
 pub enum IsaSpec {

--- a/lib/reader/src/lexer.rs
+++ b/lib/reader/src/lexer.rs
@@ -3,10 +3,14 @@
 use std::str::CharIndices;
 use std::u16;
 #[allow(unused_imports)]
-use std::ascii::AsciiExt;
+
 use cretonne::ir::types;
 use cretonne::ir::{Value, Ebb};
 use error::Location;
+
+// for some reason, this doesn't need to be included when compiled with `no_std`
+#[cfg(feature = "std")]
+use std::ascii::AsciiExt;
 
 /// A Token returned from the `Lexer`.
 ///

--- a/lib/reader/src/lib.rs
+++ b/lib/reader/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
 //! Cretonne file reader library.
 //!
 //! The cton_reader library supports reading .cton files. This functionality is needed for testing
@@ -6,6 +8,21 @@
 #![deny(missing_docs)]
 
 extern crate cretonne;
+
+#[cfg(not(feature = "std"))]
+#[macro_use] extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+extern crate hashmap_core;
+
+#[cfg(not(feature = "std"))]
+mod std {
+    pub use core::{fmt, result, u16, u32, str, mem};
+    pub use alloc::{vec, string, boxed};
+    pub mod collections {
+        pub use hashmap_core::HashMap;
+    }
+}
 
 pub use error::{Location, Result, Error};
 pub use parser::{parse_functions, parse_test};

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::{u16, u32};
 use std::mem;
+use std::vec::Vec;
+use std::string::ToString;
 use cretonne::ir::{Function, Ebb, Opcode, Value, Type, ExternalName, CallConv, StackSlotData,
                    JumpTable, JumpTableData, Signature, AbiParam, ArgumentExtension, ExtFuncData,
                    SigRef, FuncRef, StackSlot, ValueLoc, ArgumentLoc, MemFlags, GlobalVar,

--- a/lib/reader/src/testcommand.rs
+++ b/lib/reader/src/testcommand.rs
@@ -13,6 +13,7 @@
 //! the general format into a `TestCommand` data structure.
 
 use std::fmt::{self, Display, Formatter};
+use std::vec::Vec;
 
 /// A command appearing in a test file.
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/lib/reader/src/testfile.rs
+++ b/lib/reader/src/testfile.rs
@@ -10,6 +10,7 @@ use testcommand::TestCommand;
 use isaspec::IsaSpec;
 use sourcemap::SourceMap;
 use error::Location;
+use std::vec::Vec;
 
 /// A parsed test case.
 ///


### PR DESCRIPTION
This pull request adds a default feature called `std` to `cretonne`, `frontend`, `native`, and `reader`.

This pull request also adds `hashmap_core` as a dependency to `cretonne` and `reader`. The internals of this crate are behind a `disable` feature gate, meaning that when used in a crate that can use `std`, this crate does absolutely nothing.

If a crate needs to use cretonne on bare-metal, they can use those four crates with `default-feature = false`.
```toml
[dependency.cretonne]
    version = "..."
    default-features = false
```

Let me know if you want any changes made.