### PR TITLE
Position-Independent Code

### DIFF
--- a/filetests/isa/intel/binary64-pic.cton
+++ b/filetests/isa/intel/binary64-pic.cton
@@ -1,0 +1,54 @@
+; binary emission of 64-bit code.
+test binemit
+set is_64bit
+set is_compressed
+set is_pic
+isa intel haswell
+
+; The binary encodings can be verified with the command:
+;
+;   sed -ne 's/^ *; asm: *//p' filetests/isa/intel/binary64-pic.cton | llvm-mc -show-encoding -triple=x86_64
+;
+
+; Tests for i64 instructions.
+function %I64() {
+    fn0 = function %foo()
+    sig0 = ()
+
+    gv0 = globalsym %some_gv
+
+    ; Use incoming_arg stack slots because they won't be relocated by the frame
+    ; layout.
+    ss0 = incoming_arg 8, offset 0
+    ss1 = incoming_arg 1024, offset -1024
+    ss2 = incoming_arg 1024, offset -2048
+    ss3 = incoming_arg 8, offset -2056
+
+ebb0:
+
+    ; asm: call foo@PLT
+    call fn0()                                  ; bin: e8 PLTRel4(%foo) 00000000
+
+    ; asm: mov 0x0(%rip), %rax
+    [-,%rax]            v0 = func_addr.i64 fn0        ; bin: 48 8b 05 GotPCRel4(%foo) 00000000
+    ; asm: mov 0x0(%rip), %rsi
+    [-,%rsi]            v1 = func_addr.i64 fn0        ; bin: 48 8b 35 GotPCRel4(%foo) 00000000
+    ; asm: mov 0x0(%rip), %r10
+    [-,%r10]            v2 = func_addr.i64 fn0        ; bin: 4c 8b 15 GotPCRel4(%foo) 00000000
+
+    ; asm: call *%rax
+    call_indirect sig0, v0()                  ; bin: ff d0
+    ; asm: call *%rsi
+    call_indirect sig0, v1()                  ; bin: ff d6
+    ; asm: call *%r10
+    call_indirect sig0, v2()                  ; bin: 41 ff d2
+
+    ; asm: mov 0x0(%rip), %rcx
+    [-,%rcx]            v3 = globalsym_addr.i64 gv0    ; bin: 48 8b 0d GotPCRel4(%some_gv) 00000000
+    ; asm: mov 0x0(%rip), %rsi
+    [-,%rsi]            v4 = globalsym_addr.i64 gv0    ; bin: 48 8b 35 GotPCRel4(%some_gv) 00000000
+    ; asm: mov 0x0(%rip), %r10
+    [-,%r10]            v5 = globalsym_addr.i64 gv0    ; bin: 4c 8b 15 GotPCRel4(%some_gv) 00000000
+
+    return
+}

--- a/lib/cretonne/meta/base/settings.py
+++ b/lib/cretonne/meta/base/settings.py
@@ -29,6 +29,8 @@ enable_verifier = BoolSetting(
 
 is_64bit = BoolSetting("Enable 64-bit code generation")
 
+is_pic = BoolSetting("Enable Position-Independent Code generation")
+
 return_at_end = BoolSetting(
         """
         Generate functions with at most a single return instruction at the

--- a/lib/cretonne/meta/isa/intel/recipes.py
+++ b/lib/cretonne/meta/isa/intel/recipes.py
@@ -560,11 +560,11 @@ allones_fnaddr8 = TailRecipe(
 
 got_fnaddr8 = TailRecipe(
         'got_fnaddr8', FuncAddr, size=5, ins=(), outs=GPR,
-        # rex2 is a hack at the moment to get one that sets the `r` bit in rex
-        # rm for modrm_rm is 5 to get RIP-relative addressing
+        # rex2 gets passed 0 for r/m register because the upper bit of
+        # r/m doesnt get decoded when in rip-relative addressing mode.
         emit='''
         PUT_OP(bits, rex2(0, out_reg0), sink);
-        modrm_rm(5, out_reg0, sink);
+        modrm_riprel(out_reg0, sink);
         sink.reloc_external(Reloc::IntelGotPCRel4,
                             &func.dfg.ext_funcs[func_ref].name);
         sink.put4(0);

--- a/lib/cretonne/src/binemit/mod.rs
+++ b/lib/cretonne/src/binemit/mod.rs
@@ -28,6 +28,10 @@ pub enum Reloc {
     IntelAbs4,
     /// Intel absolute 8-byte
     IntelAbs8,
+    /// Intel GOT PC-relative 4-byte
+    IntelGotPCRel4,
+    /// Intel PLT-relative 4-byte
+    IntelPLTRel4,
     /// Arm32 call target
     Arm32Call,
     /// Arm64 call target
@@ -44,6 +48,8 @@ impl fmt::Display for Reloc {
             Reloc::IntelPCRel4 => write!(f, "{}", "PCRel4"),
             Reloc::IntelAbs4 => write!(f, "{}", "Abs4"),
             Reloc::IntelAbs8 => write!(f, "{}", "Abs8"),
+            Reloc::IntelGotPCRel4 => write!(f, "{}", "GotPCRel4"),
+            Reloc::IntelPLTRel4 => write!(f, "{}", "PLTRel4"),
             Reloc::Arm32Call | Reloc::Arm64Call | Reloc::RiscvCall => write!(f, "{}", "Call"),
         }
     }

--- a/lib/cretonne/src/isa/intel/binemit.rs
+++ b/lib/cretonne/src/isa/intel/binemit.rs
@@ -180,6 +180,13 @@ fn modrm_rm<CS: CodeSink + ?Sized>(rm: RegUnit, reg: RegUnit, sink: &mut CS) {
     sink.put1(b);
 }
 
+/// Emit a mode 00 Mod/RM byte, with a rip-relative displacement in 64-bit mode. Effective address
+/// is calculated by adding displacement to 64-bit rip of next instruction. See intel Sw dev manual
+/// section 2.2.1.6.
+fn modrm_riprel<CS: CodeSink + ?Sized>(reg: RegUnit, sink: &mut CS) {
+    modrm_rm(0b101, reg, sink)
+}
+
 /// Emit a mode 01 ModR/M byte. This is a register-indirect addressing mode with 8-bit
 /// displacement.
 /// Register %rsp is invalid for `rm`. It indicates the presence of a SIB byte.

--- a/lib/cretonne/src/settings.rs
+++ b/lib/cretonne/src/settings.rs
@@ -347,6 +347,7 @@ mod tests {
                     opt_level = \"default\"\n\
                     enable_verifier = true\n\
                     is_64bit = false\n\
+                    is_pic = false\n\
                     return_at_end = false\n\
                     is_compressed = false\n\
                     enable_float = true\n\


### PR DESCRIPTION
This PR adds support for PIC code generation to the Intel 64-bit isa.

* A boolean setting "is_pic" is added to the base settings.
* The relocation types required for PIC are added to the Reloc enum.
* Added the appropriate recipes and encodings to the intel isa.
* Added a filetest for testing the encoding of the instructions added.