### PR TITLE
refactor Reloc to an enum of every architecture's reloc types

### DIFF
--- a/lib/cretonne/meta/isa/intel/recipes.py
+++ b/lib/cretonne/meta/isa/intel/recipes.py
@@ -521,7 +521,7 @@ fnaddr4 = TailRecipe(
         'fnaddr4', FuncAddr, size=4, ins=(), outs=GPR,
         emit='''
         PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
-        sink.reloc_external(RelocKind::Abs4.into(),
+        sink.reloc_external(Reloc::IntelAbs4,
                             &func.dfg.ext_funcs[func_ref].name);
         sink.put4(0);
         ''')
@@ -531,7 +531,7 @@ fnaddr8 = TailRecipe(
         'fnaddr8', FuncAddr, size=8, ins=(), outs=GPR,
         emit='''
         PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
-        sink.reloc_external(RelocKind::Abs8.into(),
+        sink.reloc_external(Reloc::IntelAbs8,
                             &func.dfg.ext_funcs[func_ref].name);
         sink.put8(0);
         ''')
@@ -541,7 +541,7 @@ allones_fnaddr4 = TailRecipe(
         'allones_fnaddr4', FuncAddr, size=4, ins=(), outs=GPR,
         emit='''
         PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
-        sink.reloc_external(RelocKind::Abs4.into(),
+        sink.reloc_external(Reloc::IntelAbs4,
                             &func.dfg.ext_funcs[func_ref].name);
         // Write the immediate as `!0` for the benefit of BaldrMonkey.
         sink.put4(!0);
@@ -552,7 +552,7 @@ allones_fnaddr8 = TailRecipe(
         'allones_fnaddr8', FuncAddr, size=8, ins=(), outs=GPR,
         emit='''
         PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
-        sink.reloc_external(RelocKind::Abs8.into(),
+        sink.reloc_external(Reloc::IntelAbs8,
                             &func.dfg.ext_funcs[func_ref].name);
         // Write the immediate as `!0` for the benefit of BaldrMonkey.
         sink.put8(!0);
@@ -563,7 +563,7 @@ gvaddr4 = TailRecipe(
         'gvaddr4', UnaryGlobalVar, size=4, ins=(), outs=GPR,
         emit='''
         PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
-        sink.reloc_external(RelocKind::Abs4.into(),
+        sink.reloc_external(Reloc::IntelAbs4,
                             &func.global_vars[global_var].symbol_name());
         sink.put4(0);
         ''')
@@ -573,7 +573,7 @@ gvaddr8 = TailRecipe(
         'gvaddr8', UnaryGlobalVar, size=8, ins=(), outs=GPR,
         emit='''
         PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
-        sink.reloc_external(RelocKind::Abs8.into(),
+        sink.reloc_external(Reloc::IntelAbs8,
                             &func.global_vars[global_var].symbol_name());
         sink.put8(0);
         ''')
@@ -848,7 +848,7 @@ call_id = TailRecipe(
         'call_id', Call, size=4, ins=(), outs=(),
         emit='''
         PUT_OP(bits, BASE_REX, sink);
-        sink.reloc_external(RelocKind::PCRel4.into(),
+        sink.reloc_external(Reloc::IntelPCRel4,
                             &func.dfg.ext_funcs[func_ref].name);
         sink.put4(0);
         ''')

--- a/lib/cretonne/meta/isa/riscv/recipes.py
+++ b/lib/cretonne/meta/isa/riscv/recipes.py
@@ -183,7 +183,7 @@ UJ = EncRecipe(
 UJcall = EncRecipe(
         'UJcall', Call, size=4, ins=(), outs=(),
         emit='''
-        sink.reloc_external(RelocKind::Call.into(),
+        sink.reloc_external(Reloc::RiscvCall,
                             &func.dfg.ext_funcs[func_ref].name);
         // rd=%x1 is the standard link register.
         put_uj(bits, 0, 1, sink);

--- a/lib/cretonne/src/binemit/mod.rs
+++ b/lib/cretonne/src/binemit/mod.rs
@@ -11,6 +11,7 @@ pub use self::memorysink::{MemoryCodeSink, RelocSink};
 
 use ir::{ExternalName, JumpTable, Function, Inst};
 use regalloc::RegDiversions;
+use std::fmt;
 
 /// Offset in bytes from the beginning of the function.
 ///
@@ -18,8 +19,35 @@ use regalloc::RegDiversions;
 /// depends on the *host* platform, not the *target* platform.
 pub type CodeOffset = u32;
 
-/// Relocation kinds depend on the current ISA.
-pub struct Reloc(pub u16);
+/// Relocation kinds for every ISA
+#[derive(Debug)]
+pub enum Reloc {
+    /// Intel PC-relative 4-byte
+    IntelPCRel4,
+    /// Intel absolute 4-byte
+    IntelAbs4,
+    /// Intel absolute 8-byte
+    IntelAbs8,
+    /// Arm32 call target
+    Arm32Call,
+    /// Arm64 call target
+    Arm64Call,
+    /// RISC-V call target
+    RiscvCall,
+}
+
+impl fmt::Display for Reloc {
+    /// Display trait implementation drops the arch, since its used in contexts where the arch is
+    /// already unambigious, e.g. cton syntax with isa specified. In other contexts, use Debug.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Reloc::IntelPCRel4 => write!(f, "{}", "PCRel4"),
+            Reloc::IntelAbs4 => write!(f, "{}", "Abs4"),
+            Reloc::IntelAbs8 => write!(f, "{}", "Abs8"),
+            Reloc::Arm32Call | Reloc::Arm64Call | Reloc::RiscvCall => write!(f, "{}", "Call"),
+        }
+    }
+}
 
 /// Abstract interface for adding bytes to the code segment.
 ///

--- a/lib/cretonne/src/isa/arm32/binemit.rs
+++ b/lib/cretonne/src/isa/arm32/binemit.rs
@@ -5,5 +5,3 @@ use ir::{Function, Inst};
 use regalloc::RegDiversions;
 
 include!(concat!(env!("OUT_DIR"), "/binemit-arm32.rs"));
-
-pub static RELOC_NAMES: [&'static str; 1] = ["Call"];

--- a/lib/cretonne/src/isa/arm32/mod.rs
+++ b/lib/cretonne/src/isa/arm32/mod.rs
@@ -107,8 +107,4 @@ impl TargetIsa for Isa {
     fn emit_function(&self, func: &ir::Function, sink: &mut MemoryCodeSink) {
         emit_function(func, binemit::emit_inst, sink)
     }
-
-    fn reloc_names(&self) -> &'static [&'static str] {
-        &binemit::RELOC_NAMES
-    }
 }

--- a/lib/cretonne/src/isa/arm64/binemit.rs
+++ b/lib/cretonne/src/isa/arm64/binemit.rs
@@ -5,5 +5,3 @@ use ir::{Function, Inst};
 use regalloc::RegDiversions;
 
 include!(concat!(env!("OUT_DIR"), "/binemit-arm64.rs"));
-
-pub static RELOC_NAMES: [&'static str; 1] = ["Call"];

--- a/lib/cretonne/src/isa/arm64/mod.rs
+++ b/lib/cretonne/src/isa/arm64/mod.rs
@@ -100,8 +100,4 @@ impl TargetIsa for Isa {
     fn emit_function(&self, func: &ir::Function, sink: &mut MemoryCodeSink) {
         emit_function(func, binemit::emit_inst, sink)
     }
-
-    fn reloc_names(&self) -> &'static [&'static str] {
-        &binemit::RELOC_NAMES
-    }
 }

--- a/lib/cretonne/src/isa/intel/binemit.rs
+++ b/lib/cretonne/src/isa/intel/binemit.rs
@@ -9,26 +9,6 @@ use super::registers::RU;
 
 include!(concat!(env!("OUT_DIR"), "/binemit-intel.rs"));
 
-/// Intel relocations.
-pub enum RelocKind {
-    /// A 4-byte relative function reference. Based from relocation + 4 bytes.
-    PCRel4,
-
-    /// A 4-byte absolute function reference.
-    Abs4,
-
-    /// An 8-byte absolute function reference.
-    Abs8,
-}
-
-pub static RELOC_NAMES: [&'static str; 3] = ["PCRel4", "Abs4", "Abs8"];
-
-impl Into<Reloc> for RelocKind {
-    fn into(self) -> Reloc {
-        Reloc(self as u16)
-    }
-}
-
 // Convert a stack base to the corresponding register.
 fn stk_base(base: StackBase) -> RegUnit {
     let ru = match base {

--- a/lib/cretonne/src/isa/intel/mod.rs
+++ b/lib/cretonne/src/isa/intel/mod.rs
@@ -111,10 +111,6 @@ impl TargetIsa for Isa {
         emit_function(func, binemit::emit_inst, sink)
     }
 
-    fn reloc_names(&self) -> &'static [&'static str] {
-        &binemit::RELOC_NAMES
-    }
-
     fn prologue_epilogue(&self, func: &mut ir::Function) -> result::CtonResult {
         let _tt = timing::prologue_epilogue();
         abi::prologue_epilogue(func, self)

--- a/lib/cretonne/src/isa/mod.rs
+++ b/lib/cretonne/src/isa/mod.rs
@@ -272,10 +272,4 @@ pub trait TargetIsa {
     ///
     /// This is more performant than calling `emit_inst` for each instruction.
     fn emit_function(&self, func: &ir::Function, sink: &mut binemit::MemoryCodeSink);
-
-    /// Get a static array of names associated with relocations in this ISA.
-    ///
-    /// This array can be indexed by the contents of `binemit::Reloc` objects passed to a
-    /// `CodeSink`.
-    fn reloc_names(&self) -> &'static [&'static str];
 }

--- a/lib/cretonne/src/isa/riscv/binemit.rs
+++ b/lib/cretonne/src/isa/riscv/binemit.rs
@@ -9,20 +9,6 @@ use std::u32;
 
 include!(concat!(env!("OUT_DIR"), "/binemit-riscv.rs"));
 
-/// RISC-V relocation kinds.
-pub enum RelocKind {
-    /// A jal call to a function.
-    Call,
-}
-
-pub static RELOC_NAMES: [&'static str; 1] = ["Call"];
-
-impl Into<Reloc> for RelocKind {
-    fn into(self) -> Reloc {
-        Reloc(self as u16)
-    }
-}
-
 /// R-type instructions.
 ///
 ///   31     24  19  14     11 6

--- a/lib/cretonne/src/isa/riscv/mod.rs
+++ b/lib/cretonne/src/isa/riscv/mod.rs
@@ -107,10 +107,6 @@ impl TargetIsa for Isa {
     fn emit_function(&self, func: &ir::Function, sink: &mut MemoryCodeSink) {
         emit_function(func, binemit::emit_inst, sink)
     }
-
-    fn reloc_names(&self) -> &'static [&'static str] {
-        &binemit::RELOC_NAMES
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Rather than use a struct-wrapped integer to encode an architecture-specific relocation type, this PR instead makes an enum that has all of the relocation types needed by all of the architectures. This way, the relocation can be made public to crate users without having to expose any of the isa binemit internals.

Common types (like `Call`, which is the same for arm32, arm64, and riscv) is given one enumeration value for each architecture that uses it, so that its easier for individual architectures to change how their relocations work without breaking others.

The enumeration has a `Display` trait that drops the architecture name, so that the output text is identical to the static string array previously used. This also allowed us to drop the `reloc_names` function from the `TargetIsa` trait.

This implementation is based on the comment here:
https://github.com/stoklund/cretonne/pull/206#issuecomment-350905016