### PR TITLE
Fix static heap oob traps

### DIFF
--- a/filetests/isa/intel/legalize-memory.cton
+++ b/filetests/isa/intel/legalize-memory.cton
@@ -65,6 +65,27 @@ ebb0(v0: i32, v999: i64):
     return v4
 }
 
+function %staticheap_static_oob_sm64(i32, i64 vmctx) -> f32 spiderwasm {
+    gv0 = vmctx+64
+    heap0 = static gv0, min 0x1000, bound 0x1000_0000, guard 0x8000_0000
+
+ebb0(v0: i32, v999: i64):
+    ; Everything after the obviously OOB access should be eliminated, leaving
+    ; the `trap heap_oob` instruction as the terminator of the Ebb and moving
+    ; the remainder of the instructions into an inaccessible Ebb.
+    ; check: $ebb0(
+    ; nextln:     trap heap_oob
+    ; check: ebb1:
+    ; nextln:     v2 = iconst.i64 0
+    ; nextln:     v3 = load.f32 v2+16
+    ; nextln:     return v3
+    ; nextln: }
+    v1 = heap_addr.i64 heap0, v0, 0x1000_0001
+    v2 = load.f32 v1+16
+    return v2
+}
+
+
 ; SpiderMonkey VM-style static 4+2 GB heap.
 ; Offsets >= 2 GB do require a boundscheck.
 function %staticheap_sm64(i32, i64 vmctx) -> f32 spiderwasm {


### PR DESCRIPTION
During the expansion of a static heap lookup Cretonne checks whether an address can be statically determined to be out of bounds, and emits an unconditional trap in place of the lookup. This is great, but the problem is that `trap` is a terminator instruction and now falls into the middle of an Ebb. And so compilation fails with: 
```
a terminator instruction was encountered before the end of ebb11
```

This patch splits the Ebb after emitting the trap. However, this breaks cfg and the domtree and probably everything else too. So, in addition, we also recompute the cfg, the domtree, and run the unreachable code elimination pass as well.

I'm sure there's a more efficient way to handle this, but it was not clear at first glance. Happy to change this to make it less brute-force.

Thanks!