### PR TITLE
Fix the relocation addend for PIC calls on Intel

### DIFF
--- a/filetests/isa/intel/binary64-pic.cton
+++ b/filetests/isa/intel/binary64-pic.cton
@@ -27,7 +27,7 @@ function %I64() {
 ebb0:
 
     ; asm: call foo@PLT
-    call fn0()                                  ; bin: e8 PLTRel4(%foo) 00000000
+    call fn0()                                  ; bin: e8 PLTRel4(%foo-4) 00000000
 
     ; asm: mov 0x0(%rip), %rax
     [-,%rax]            v0 = func_addr.i64 fn0        ; bin: 48 8b 05 GOTPCRel4(%foo-4) 00000000

--- a/lib/cretonne/meta/isa/intel/recipes.py
+++ b/lib/cretonne/meta/isa/intel/recipes.py
@@ -899,7 +899,7 @@ call_plt_id = TailRecipe(
         PUT_OP(bits, BASE_REX, sink);
         sink.reloc_external(Reloc::IntelPLTRel4,
                             &func.dfg.ext_funcs[func_ref].name,
-                            0);
+                            -4);
         sink.put4(0);
         ''')
 


### PR DESCRIPTION
Hello!

Currently the addend for PLTRel4 relocation that we output for position-independent calls has an incorrect addend. After linking this causes it to jump 4 bytes past the beginning of the PLT thunk, leading to "fun".

This PR corrects the addend and the test for it. Thanks!