### PR TITLE
cretonne::Context: add for_function constructor

### DIFF
--- a/lib/cretonne/src/context.rs
+++ b/lib/cretonne/src/context.rs
@@ -49,8 +49,16 @@ impl Context {
     /// The returned instance should be reused for compiling multiple functions in order to avoid
     /// needless allocator thrashing.
     pub fn new() -> Self {
+        Context::for_function(Function::new())
+    }
+
+    /// Allocate a new compilation context with an existing Function.
+    ///
+    /// The returned instance should be reused for compiling multiple functions in order to avoid
+    /// needless allocator thrashing.
+    pub fn for_function(func: Function) -> Self {
         Self {
-            func: Function::new(),
+            func: func,
             cfg: ControlFlowGraph::new(),
             domtree: DominatorTree::new(),
             regalloc: regalloc::Context::new(),


### PR DESCRIPTION
This is a much simpler change that makes it obvious that a Context can be created and some arbitrary Function can be put into it. Without a constructor I wasn't sure whether there was some invariant (which is my bad, I didn't fully understand what Context was for, the docs should have been enough).