### PR TITLE
Restrict R12 dereferencing

### DIFF
--- a/lib/cretonne/meta/isa/intel/registers.py
+++ b/lib/cretonne/meta/isa/intel/registers.py
@@ -46,10 +46,13 @@ FlagRegs = RegBank(
         names=['eflags'])
 
 GPR = RegClass(IntRegs)
+# Certain types of deref encodings cannot be used with all registers.
+#   R13/RBP cannot be used with zero-offset load or store instructions.
+#   R12 cannot be used with a non-SIB-byte encoding of all derefs.
+GPR_DEREF_SAFE = GPR.without(GPR.r12)
+GPR_ZERO_DEREF_SAFE = GPR_DEREF_SAFE.without(GPR.rbp, GPR.r13)
 GPR8 = GPR[0:8]
-# In certain instructions, RBP and R13 are interpreted as RIP-relative.
-GPR_NORIP = GPR.without(GPR.rbp, GPR.r13)
-GPR8_NORIP = GPR8.without(GPR.rbp)
+GPR8_ZERO_DEREF_SAFE = GPR8.without(GPR.rbp)
 ABCD = GPR[0:4]
 FPR = RegClass(FloatRegs)
 FPR8 = FPR[0:8]


### PR DESCRIPTION
I found another issue similar to the RBP/R13 issue (#211).

The encoding of R12 in dereferencing loads and stores is equivalent to the combination of bits that indicate the presence of a SIB-byte. So, Intel does the logical thing and requires that a SIB byte be appended to the instructions. 

Unfortunately, this doesn't just affect zero-offset loads and stores like the last one, but all of them. You can see what I mean below...

Zero-offset:
```
0:  41 89 18                mov    DWORD PTR [r8],ebx
3:  41 89 19                mov    DWORD PTR [r9],ebx
6:  41 89 1a                mov    DWORD PTR [r10],ebx
9:  41 89 1b                mov    DWORD PTR [r11],ebx
c:  41 89 1c 24             mov    DWORD PTR [r12],ebx
10: 41 89 5d 00             mov    DWORD PTR [r13+0x0],ebx
14: 41 89 1e                mov    DWORD PTR [r14],ebx
17: 41 89 1f                mov    DWORD PTR [r15],ebx
```

8-bit offset:
```
1a: 41 89 58 01             mov    DWORD PTR [r8+0x1],ebx
1e: 41 89 59 01             mov    DWORD PTR [r9+0x1],ebx
22: 41 89 5a 01             mov    DWORD PTR [r10+0x1],ebx
26: 41 89 5b 01             mov    DWORD PTR [r11+0x1],ebx
2a: 41 89 5c 24 01          mov    DWORD PTR [r12+0x1],ebx
2f: 41 89 5d 01             mov    DWORD PTR [r13+0x1],ebx
33: 41 89 5e 01             mov    DWORD PTR [r14+0x1],ebx
37: 41 89 5f 01             mov    DWORD PTR [r15+0x1],ebx
```

32-bit offset:
```
3b: 41 89 80 00 00 00 01    mov    DWORD PTR [r8+0x1000000],eax
42: 41 89 81 00 00 00 01    mov    DWORD PTR [r9+0x1000000],eax
49: 41 89 82 00 00 00 01    mov    DWORD PTR [r10+0x1000000],eax
50: 41 89 83 00 00 00 01    mov    DWORD PTR [r11+0x1000000],eax
57: 41 89 84 24 00 00 00    mov    DWORD PTR [r12+0x1000000],eax
5e: 01
5f: 41 89 85 00 00 00 01    mov    DWORD PTR [r13+0x1000000],eax
66: 41 89 86 00 00 00 01    mov    DWORD PTR [r14+0x1000000],eax
6d: 41 89 87 00 00 00 01    mov    DWORD PTR [r15+0x1000000],eax
```

You can see that, unlike every other register, the SIB byte is always included for R12.

All that said, I'm not sure this is the best way to fix this. I tried to wrap this up with the R13/RBP changes from before in a reasonable way. But it's beginning to feel pretty clunky. Any ideas for ways to improve this? It's unfortunate that we're needing to actually prevent the use of these registers for loads and stores altogether.