### PR TITLE
Adds support for legalizing CLZ, CTZ and POPCOUNT on baseline

### DIFF
--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -700,6 +700,7 @@ Operations
 ==========
 
 .. autoinst:: select
+.. autoinst:: selectif
 
 Constant materialization
 ------------------------

--- a/filetests/isa/intel/baseline_clz_ctz_popcount.cton
+++ b/filetests/isa/intel/baseline_clz_ctz_popcount.cton
@@ -1,0 +1,51 @@
+
+test compile
+set is_64bit
+isa intel baseline
+
+
+; clz/ctz on 64 bit operands
+
+function %i64_clz(i64) -> i64 {
+ebb0(v10: i64):
+  v11 = clz v10
+  ; check: x86_bsr
+  ; check: selectif.i64
+  return v11
+}
+
+function %i64_ctz(i64) -> i64 {
+ebb1(v20: i64):
+  v21 = ctz v20
+  ; check: x86_bsf
+  ; check: selectif.i64
+  return v21
+}
+
+
+; clz/ctz on 32 bit operands
+
+function %i32_clz(i32) -> i32 {
+ebb0(v10: i32):
+  v11 = clz v10
+  ; check: x86_bsr
+  ; check: selectif.i32
+  return v11
+}
+
+function %i32_ctz(i32) -> i32 {
+ebb1(v20: i32):
+  v21 = ctz v20
+  ; check: x86_bsf
+  ; check: selectif.i32
+  return v21
+}
+
+
+; popcount on 64 bit operands
+
+function %i64_popcount(i64) -> i64 {
+ebb0(v30: i64):
+  v31 = popcnt v30;
+  return v31;
+}

--- a/filetests/isa/intel/baseline_clz_ctz_popcount_encoding.cton
+++ b/filetests/isa/intel/baseline_clz_ctz_popcount_encoding.cton
@@ -1,0 +1,84 @@
+
+test binemit
+set is_64bit
+set is_compressed
+isa intel baseline
+
+; The binary encodings can be verified with the command:
+;
+;   sed -ne 's/^ *; asm: *//p' expclz_encoding.cton | llvm-mc -show-encoding -triple=x86_64
+;
+
+function %Foo() {
+ebb0:
+    ; 64-bit wide bsf
+
+    [-,%r11]                 v10 = iconst.i64 0x1234
+    ; asm: bsfq %r11, %rcx
+    [-,%rcx,%eflags]         v11, v12 = x86_bsf v10    ; bin: 49 0f bc cb
+
+    [-,%rdx]                 v14 = iconst.i64 0x5678
+    ; asm: bsfq %rdx, %r12
+    [-,%r12,%eflags]         v15, v16 = x86_bsf v14    ; bin: 4c 0f bc e2
+
+    ; asm: bsfq %rdx, %rdi
+    [-,%rdi,%eflags]         v17, v18 = x86_bsf v14    ; bin: 48 0f bc fa
+
+
+    ; 32-bit wide bsf
+
+    [-,%r11]                 v20 = iconst.i32 0x1234
+    ; asm: bsfl %r11d, %ecx
+    [-,%rcx,%eflags]         v21, v22 = x86_bsf v20    ; bin: 41 0f bc cb
+
+    [-,%rdx]                 v24 = iconst.i32 0x5678
+    ; asm: bsfl %edx, %r12d
+    [-,%r12,%eflags]         v25, v26 = x86_bsf v24    ; bin: 44 0f bc e2
+
+    ; urr, redundant REX prefix here (0x40).  How to get rid of it?
+    ; asm: bsfl %edx, %esi
+    [-,%rsi,%eflags]         v27, v28 = x86_bsf v24    ; bin: 40 0f bc f2
+
+
+    ; 64-bit wide bsr
+
+    [-,%r11]                 v30 = iconst.i64 0x1234
+    ; asm: bsrq %r11, %rcx
+    [-,%rcx,%eflags]         v31, v32 = x86_bsr v30    ; bin: 49 0f bd cb
+
+    [-,%rdx]                 v34 = iconst.i64 0x5678
+    ; asm: bsrq %rdx, %r12
+    [-,%r12,%eflags]         v35, v36 = x86_bsr v34    ; bin: 4c 0f bd e2
+
+    ; asm: bsrq %rdx, %rdi
+    [-,%rdi,%eflags]         v37, v38 = x86_bsr v34    ; bin: 48 0f bd fa
+
+
+    ; 32-bit wide bsr
+
+    [-,%r11]                 v40 = iconst.i32 0x1234
+    ; asm: bsrl %r11d, %ecx
+    [-,%rcx,%eflags]         v41, v42 = x86_bsr v40    ; bin: 41 0f bd cb
+
+    [-,%rdx]                 v44 = iconst.i32 0x5678
+    ; asm: bsrl %edx, %r12d
+    [-,%r12,%eflags]         v45, v46 = x86_bsr v44    ; bin: 44 0f bd e2
+
+    ; urr, redundant REX prefix here (0x40).  How to get rid of it?
+    ; asm: bsrl %edx, %esi
+    [-,%rsi,%eflags]         v47, v48 = x86_bsr v44    ; bin: 40 0f bd f2
+
+
+    ; 64-bit wide cmov
+
+    ; asm: cmoveq %rdx, %r11
+    [-,%r11]     v51 = selectif.i64 eq v48, v30, v34   ; bin: 4c 0f 44 da
+
+
+    ; 32-bit wide cmov
+
+    ; asm: cmovnel %edx, %r11d
+    [-,%r11]    v52 = selectif.i32 ne v48, v40, v44    ; bin: 44 0f 45 da
+
+    trap user0
+}

--- a/filetests/parser/tiny.cton
+++ b/filetests/parser/tiny.cton
@@ -42,7 +42,7 @@ ebb0:
 ; nextln:     $v3 = bxor v0, v2
 ; nextln: }
 
-; Polymorphic istruction controlled by second operand.
+; Polymorphic instruction controlled by second operand.
 function %select() {
 ebb0(v90: i32, v91: i32, v92: b1):
     v0 = select v92, v90, v91
@@ -50,6 +50,16 @@ ebb0(v90: i32, v91: i32, v92: b1):
 ; sameln: function %select() native {
 ; nextln: ebb0($v90: i32, $v91: i32, $v92: b1):
 ; nextln:     $v0 = select $v92, $v90, $v91
+; nextln: }
+
+; Polymorphic instruction controlled by third operand.
+function %selectif() native {
+ebb0(v95: i32, v96: i32, v97: b1):
+    v98 = selectif.i32 eq v97, v95, v96
+}
+; sameln: function %selectif() native {
+; nextln: ebb0(v0: i32, v1: i32, v2: b1):
+; nextln: v3 = selectif.i32 eq v2, v0, v1
 ; nextln: }
 
 ; Lane indexes.

--- a/lib/cretonne/meta/base/formats.py
+++ b/lib/cretonne/meta/base/formats.py
@@ -43,6 +43,8 @@ IntCond = InstructionFormat(intcc, VALUE)
 FloatCompare = InstructionFormat(floatcc, VALUE, VALUE)
 FloatCond = InstructionFormat(floatcc, VALUE)
 
+IntSelect = InstructionFormat(intcc, VALUE, VALUE, VALUE)
+
 Jump = InstructionFormat(ebb, VARIABLE_ARGS)
 Branch = InstructionFormat(VALUE, ebb, VARIABLE_ARGS)
 BranchInt = InstructionFormat(intcc, VALUE, ebb, VARIABLE_ARGS)

--- a/lib/cretonne/meta/base/instructions.py
+++ b/lib/cretonne/meta/base/instructions.py
@@ -485,6 +485,15 @@ select = Instruction(
         """,
         ins=(c, x, y), outs=a)
 
+cc    = Operand('cc', intcc, doc='Controlling condition code')
+flags = Operand('flags', iflags, doc='The machines flag register')
+
+selectif = Instruction(
+        'selectif', r"""
+        Conditional select, dependent on integer condition codes.
+        """,
+        ins=(cc, flags, x, y), outs=a)
+
 x = Operand('x', Any)
 
 copy = Instruction(

--- a/lib/cretonne/meta/gen_legalizer.py
+++ b/lib/cretonne/meta/gen_legalizer.py
@@ -355,7 +355,7 @@ def gen_xform(xform, fmt, type_sets):
 def gen_xform_group(xgrp, fmt, type_sets):
     # type: (XFormGroup, Formatter, UniqueTable) -> None
     fmt.doc_comment("Legalize the instruction pointed to by `pos`.")
-    fmt.line('#[allow(unused_variables,unused_assignments)]')
+    fmt.line('#[allow(unused_variables,unused_assignments,non_snake_case)]')
     with fmt.indented('pub fn {}('.format(xgrp.name)):
         fmt.line('inst: ir::Inst,')
         fmt.line('func: &mut ir::Function,')

--- a/lib/cretonne/meta/isa/intel/encodings.py
+++ b/lib/cretonne/meta/isa/intel/encodings.py
@@ -368,6 +368,20 @@ enc_both(base.trueif, r.seti_abcd, 0x0f, 0x90)
 enc_both(base.trueff, r.setf_abcd, 0x0f, 0x90)
 
 #
+# Conditional move (a.k.a integer select)
+#
+I64.enc(base.selectif.i64, *r.cmov.rex(0x0F, 0x40, w=1))
+I64.enc(base.selectif.i32, *r.cmov.rex(0x0F, 0x40, w=0))
+
+#
+# Bit scan forwards and reverse
+#
+I64.enc(x86.bsf.i64, *r.bsf_and_bsr.rex(0x0F, 0xBC, w=1))
+I64.enc(x86.bsf.i32, *r.bsf_and_bsr.rex(0x0F, 0xBC, w=0))
+I64.enc(x86.bsr.i64, *r.bsf_and_bsr.rex(0x0F, 0xBD, w=1))
+I64.enc(x86.bsr.i32, *r.bsf_and_bsr.rex(0x0F, 0xBD, w=0))
+
+#
 # Convert bool to int.
 #
 # This assumes that b1 is represented as an 8-bit low register with the value 0

--- a/lib/cretonne/meta/isa/intel/instructions.py
+++ b/lib/cretonne/meta/isa/intel/instructions.py
@@ -5,6 +5,7 @@ This module defines additional instructions that are useful only to the Intel
 target ISA.
 """
 
+from base.types import iflags
 from cdsl.operands import Operand
 from cdsl.typevar import TypeVar
 from cdsl.instructions import Instruction, InstructionGroup
@@ -124,5 +125,27 @@ pop = Instruction(
     in 64-bit mode, and only for i32 in 32-bit mode.
     """,
     outs=x, can_load=True, other_side_effects=True)
+
+y = Operand('y', iWord)
+rflags = Operand('rflags', iflags)
+
+bsr = Instruction(
+    'x86_bsr', r"""
+    Bit Scan Reverse -- returns the bit-index of the most significant 1
+    in the word.  Result is undefined if the argument is zero.  However, it
+    sets the Z flag depending on the argument, so it is at least easy to
+    detect and handle that case.
+
+    This is polymorphic in i32 and i64. It is implemented for both i64 and
+    i32 in 64-bit mode, and only for i32 in 32-bit mode.
+    """,
+    ins=x, outs=(y, rflags))
+
+bsf = Instruction(
+    'x86_bsf', r"""
+    Bit Scan Forwards -- returns the bit-index of the least significant 1
+    in the word.  Is otherwise identical to 'bsr', just above.
+    """,
+    ins=x, outs=(y, rflags))
 
 GROUP.close()

--- a/lib/cretonne/meta/isa/intel/recipes.py
+++ b/lib/cretonne/meta/isa/intel/recipes.py
@@ -8,6 +8,7 @@ from cdsl.registers import RegClass
 from base.formats import Unary, UnaryImm, Binary, BinaryImm, MultiAry, NullAry
 from base.formats import Trap, Call, IndirectCall, Store, Load
 from base.formats import IntCompare, FloatCompare, IntCond, FloatCond
+from base.formats import IntSelect
 from base.formats import Jump, Branch, BranchInt, BranchFloat
 from base.formats import Ternary, FuncAddr, UnaryGlobalVar
 from base.formats import RegMove, RegSpill, RegFill, CopySpecial
@@ -1019,6 +1020,32 @@ setf_abcd = TailRecipe(
         emit='''
         PUT_OP(bits | fcc2opc(cond), rex1(out_reg0), sink);
         modrm_r_bits(out_reg0, bits, sink);
+        ''')
+
+#
+# Conditional move (a.k.a integer select)
+# (maybe-REX.W) 0F 4x modrm(r,r)
+# 1 byte, modrm(r,r), is after the opcode
+#
+cmov = TailRecipe(
+        'cmov', IntSelect, size=1, ins=(FLAG.eflags, GPR, GPR), outs=1,
+        requires_prefix=False,
+        clobbers_flags=False,
+        emit='''
+        PUT_OP(bits | icc2opc(cond), rex2(in_reg2, in_reg1), sink);
+        modrm_rr(in_reg2, in_reg1, sink);
+        ''')
+
+#
+# Bit scan forwards and reverse
+#
+bsf_and_bsr = TailRecipe(
+        'bsf_and_bsr', Unary, size=1, ins=GPR, outs=(GPR, FLAG.eflags),
+        requires_prefix=False,
+        clobbers_flags=True,
+        emit='''
+        PUT_OP(bits, rex2(in_reg0, out_reg0), sink);
+        modrm_rr(in_reg0, out_reg0, sink);
         ''')
 
 #

--- a/lib/cretonne/meta/isa/intel/settings.py
+++ b/lib/cretonne/meta/isa/intel/settings.py
@@ -40,6 +40,7 @@ use_lzcnt = And(has_lzcnt)
 
 # Presets corresponding to Intel CPUs.
 
+baseline = Preset(has_sse2)
 nehalem = Preset(
         has_sse2, has_sse3, has_ssse3, has_sse41, has_sse42, has_popcnt)
 haswell = Preset(nehalem, has_bmi1, has_lzcnt)

--- a/lib/cretonne/src/ir/instructions.rs
+++ b/lib/cretonne/src/ir/instructions.rs
@@ -157,6 +157,11 @@ pub enum InstructionData {
         cond: FloatCC,
         arg: Value,
     },
+    IntSelect {
+        opcode: Opcode,
+        cond: IntCC,
+        args: [Value; 3]
+    },
     Jump {
         opcode: Opcode,
         destination: Ebb,

--- a/lib/cretonne/src/verifier/mod.rs
+++ b/lib/cretonne/src/verifier/mod.rs
@@ -358,6 +358,7 @@ impl<'a> Verifier<'a> {
             IntCond { .. } |
             FloatCompare { .. } |
             FloatCond { .. } |
+            IntSelect { .. } |
             Load { .. } |
             Store { .. } |
             RegMove { .. } |

--- a/lib/cretonne/src/write.rs
+++ b/lib/cretonne/src/write.rs
@@ -303,6 +303,8 @@ pub fn write_operands(
         IntCond { cond, arg, .. } => write!(w, " {} {}", cond, arg),
         FloatCompare { cond, args, .. } => write!(w, " {} {}, {}", cond, args[0], args[1]),
         FloatCond { cond, arg, .. } => write!(w, " {} {}", cond, arg),
+        IntSelect { cond, args, .. } => write!(w, " {} {}, {}, {}",
+                                               cond, args[0], args[1], args[2]),
         Jump {
             destination,
             ref args,

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -2119,6 +2119,28 @@ impl<'a> Parser<'a> {
                 let arg = self.match_value("expected SSA value")?;
                 InstructionData::FloatCond { opcode, cond, arg }
             }
+            InstructionFormat::IntSelect => {
+                let cond = self.match_enum("expected intcc condition code")?;
+                let guard =
+                    self.match_value("expected SSA value first operand")?;
+                self.match_token(
+                    Token::Comma,
+                    "expected ',' between operands",
+                )?;
+                let v_true =
+                    self.match_value("expected SSA value second operand")?;
+                self.match_token(
+                    Token::Comma,
+                    "expected ',' between operands",
+                )?;
+                let v_false
+                    = self.match_value("expected SSA value third operand")?;
+                InstructionData::IntSelect {
+                    opcode,
+                    cond,
+                    args: [guard, v_true, v_false],
+                }
+            }
             InstructionFormat::Call => {
                 let func_ref = self.match_fn("expected function reference").and_then(
                     |num| {


### PR DESCRIPTION
x86_64 targets (that is, devices that support SSE2 only).  Changes:

* Adds a new generic instruction, SELECTIF, that does value selection (a la
  conditional move) similarly to existing SELECT, except that it is
  controlled by condition code input and flags-register inputs.

* Adds a new Intel x86_64 variant, 'baseline', that supports SSE2 and
  nothing else.

* Adds new Intel x86_64 instructions BSR and BSF.

* Implements generic CLZ, CTZ and POPCOUNT on x86_64 'baseline' targets
  using the new BSR, BSF and SELECTIF instructions.

* Implements SELECTIF on x86_64 targets using conditional-moves.

* new test filetests/isa/intel/baseline_clz_ctz_popcount.cton
  (for legalization)

* new test filetests/isa/intel/baseline_clz_ctz_popcount_encoding.cton
  (for encoding)

* Allow lib/cretonne/meta/gen_legalizer.py to generate non-snake-caseified
  Rust without rustc complaining.