### PR TITLE
Add minimal README.md files to published crates.

### DIFF
--- a/lib/cretonne/Cargo.toml
+++ b/lib/cretonne/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 documentation = "https://cretonne.readthedocs.io/"
 repository = "https://github.com/stoklund/cretonne"
 publish = false
+readme = "README.md"
 build = "build.rs"
 
 [lib]

--- a/lib/cretonne/README.md
+++ b/lib/cretonne/README.md
@@ -1,0 +1,2 @@
+This crate contains the core Cretonne code generator. It translates code from an
+intermediate language into executable machine code.

--- a/lib/frontend/Cargo.toml
+++ b/lib/frontend/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 documentation = "https://cretonne.readthedocs.io/"
 repository = "https://github.com/stoklund/cretonne"
 publish = false
+readme = "README.md"
 
 [lib]
 name = "cton_frontend"

--- a/lib/frontend/README.md
+++ b/lib/frontend/README.md
@@ -1,0 +1,5 @@
+This crate provides a straightforward way to create a
+[Cretonne](https://crates.io/crates/cretonne) IL function and fill it with
+instructions translated from another language. It contains an SSA construction
+module that provides convenient methods for translating non-SSA variables into
+SSA Cretonne IL values via `use_var` and `def_var` calls.

--- a/lib/frontend/src/lib.rs
+++ b/lib/frontend/src/lib.rs
@@ -1,7 +1,7 @@
 //! Cretonne IL builder library.
 //!
 //! Provides a straightforward way to create a Cretonne IL function and fill it with instructions
-//! translated from another language. Contains a SSA construction module that lets you translate
+//! translated from another language. Contains an SSA construction module that lets you translate
 //! your non-SSA variables into SSA Cretonne IL values via `use_var` and `def_var` calls.
 //!
 //! To get started, create an [`IlBuilder`](struct.ILBuilder.html) and pass it as an argument

--- a/lib/native/Cargo.toml
+++ b/lib/native/Cargo.toml
@@ -3,9 +3,10 @@ name = "cretonne-native"
 version = "0.0.0"
 authors = ["The Cretonne Project Developers"]
 publish = false
-description = "Support for targetting the host with Cretonne"
+description = "Support for targeting the host with Cretonne"
 repository = "https://github.com/stoklund/cretonne"
 license = "Apache-2.0"
+readme = "README.md"
 
 [lib]
 name = "cton_native"

--- a/lib/native/README.md
+++ b/lib/native/README.md
@@ -1,0 +1,3 @@
+This crate performs autodetection of the host architecture, which can be used to
+configure [Cretonne](https://crates.io/crates/cretonne) to generate code
+specialized for the machine it's running on.

--- a/lib/reader/Cargo.toml
+++ b/lib/reader/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 documentation = "https://cretonne.readthedocs.io/"
 repository = "https://github.com/stoklund/cretonne"
 publish = false
+readme = "README.md"
 
 [lib]
 name = "cton_reader"

--- a/lib/reader/README.md
+++ b/lib/reader/README.md
@@ -1,0 +1,3 @@
+This crate library supports reading .cton files. This functionality is needed
+for testing [Cretonne](https://crates.io/crates/cretonne), but is not essential
+for a JIT compiler.

--- a/lib/wasm/Cargo.toml
+++ b/lib/wasm/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 description = "Translator from WebAssembly to Cretonne IL"
 repository = "https://github.com/stoklund/cretonne"
 license = "Apache-2.0"
+readme = "README.md"
 
 [lib]
 name = "cton_wasm"

--- a/lib/wasm/README.md
+++ b/lib/wasm/README.md
@@ -1,0 +1,3 @@
+This crate performs the translation from a wasm module in binary format to the
+in-memory representation of the [Cretonne](https://crates.io/crates/cretonne)
+IL.


### PR DESCRIPTION
This will put descriptions on the packages' crates.io pages.