### PR TITLE
Fixes #244: Prints the generated code/wasm bytecode size with -s

### DIFF
--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -92,6 +92,9 @@ pub struct DummyEnvironment {
 
     /// Function translation.
     trans: FuncTranslator,
+
+    /// Vector of wasm bytecode size for each function.
+    pub func_bytecode_sizes: Vec<usize>,
 }
 
 impl DummyEnvironment {
@@ -105,6 +108,7 @@ impl DummyEnvironment {
         Self {
             info: DummyModuleInfo::with_flags(flags),
             trans: FuncTranslator::new(),
+            func_bytecode_sizes: Vec::new(),
         }
     }
 
@@ -384,6 +388,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
                 .map_err(|e| String::from(e.description()))?;
             func
         };
+        self.func_bytecode_sizes.push(body_bytes.len());
         self.info.function_bodies.push(func);
         Ok(())
     }

--- a/src/cton-util.rs
+++ b/src/cton-util.rs
@@ -32,7 +32,7 @@ Usage:
     cton-util filecheck [-v] <file>
     cton-util print-cfg <file>...
     cton-util compile [-vpT] [--set <set>]... [--isa <isa>] <file>...
-    cton-util wasm [-ctvpT] [--set <set>]... [--isa <isa>] <file>...
+    cton-util wasm [-ctvpTs] [--set <set>]... [--isa <isa>] <file>...
     cton-util --help | --version
 
 Options:
@@ -41,6 +41,8 @@ Options:
                     print pass timing report
     -t, --just-decode
                     just decode WebAssembly to Cretonne IL
+    -s, --print-size
+                    prints generated code size
     -c, --check-translation
                     just checks the correctness of Cretonne IL translated from WebAssembly
     -p, --print     print the resulting Cretonne IL
@@ -67,6 +69,7 @@ struct Args {
     flag_set: Vec<String>,
     flag_isa: String,
     flag_time_passes: bool,
+    flag_print_size: bool,
 }
 
 /// A command either succeeds or fails with an error message.
@@ -103,6 +106,7 @@ fn cton_util() -> CommandResult {
             args.flag_print,
             args.flag_set,
             args.flag_isa,
+            args.flag_print_size,
         )
     } else {
         // Debugging / shouldn't happen with proper command line handling above.


### PR DESCRIPTION
This implements the idea presented in #244, including recording the bytecode size of each function when it's read in the DummyEnvironment (I don't think we need it in other environment?).

I sparkled a few `\n` in the code because it visually helped me understanding parts of the code that are related to each other as well (also a nice side-effect: makes motion in vim much easier with `{` and `}`). Happy to revert these changes if you prefer the tighter formatting.

@stoklund, can you have a look please? Thanks!